### PR TITLE
geom_alt props

### DIFF
--- a/data/421/172/899/421172899.geojson
+++ b/data/421/172/899/421172899.geojson
@@ -214,6 +214,9 @@
     },
     "wof:country":"PG",
     "wof:created":1459008958,
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"0554cff6c4fd6717a331aae2840e01fc",
     "wof:hierarchy":[
         {
@@ -225,7 +228,7 @@
         }
     ],
     "wof:id":421172899,
-    "wof:lastmodified":1566678592,
+    "wof:lastmodified":1582343950,
     "wof:name":"Alotau",
     "wof:parent_id":1091702001,
     "wof:placetype":"locality",

--- a/data/856/323/47/85632347.geojson
+++ b/data/856/323/47/85632347.geojson
@@ -955,6 +955,7 @@
     "src:geom":"whosonfirst",
     "src:geom_alt":[
         "meso",
+        "naturalearth",
         "naturalearth"
     ],
     "src:geom_via":"meso",
@@ -1011,6 +1012,11 @@
     },
     "wof:country":"PG",
     "wof:country_alpha3":"PNG",
+    "wof:geom_alt":[
+        "meso",
+        "naturalearth-display-terrestrial-zoom6",
+        "naturalearth"
+    ],
     "wof:geomhash":"a796290eee81d92a9806ac0dc425a3e6",
     "wof:hierarchy":[
         {
@@ -1029,7 +1035,7 @@
         "eng",
         "hmo"
     ],
-    "wof:lastmodified":1566677986,
+    "wof:lastmodified":1582343938,
     "wof:name":"Papua New Guinea",
     "wof:parent_id":102191583,
     "wof:placetype":"country",

--- a/data/856/323/47/85632347.geojson
+++ b/data/856/323/47/85632347.geojson
@@ -955,7 +955,6 @@
     "src:geom":"whosonfirst",
     "src:geom_alt":[
         "meso",
-        "naturalearth",
         "naturalearth"
     ],
     "src:geom_via":"meso",
@@ -1035,7 +1034,7 @@
         "eng",
         "hmo"
     ],
-    "wof:lastmodified":1582343938,
+    "wof:lastmodified":1583222896,
     "wof:name":"Papua New Guinea",
     "wof:parent_id":102191583,
     "wof:placetype":"country",

--- a/data/856/765/13/85676513.geojson
+++ b/data/856/765/13/85676513.geojson
@@ -284,6 +284,9 @@
         "wk:page":"Enga Province"
     },
     "wof:country":"PG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"278640bcce0e8fa165379e13ecaa475a",
     "wof:hierarchy":[
         {
@@ -303,7 +306,7 @@
         "eng",
         "hmo"
     ],
-    "wof:lastmodified":1566677985,
+    "wof:lastmodified":1582343937,
     "wof:name":"Enga",
     "wof:parent_id":85632347,
     "wof:placetype":"region",

--- a/data/856/765/19/85676519.geojson
+++ b/data/856/765/19/85676519.geojson
@@ -291,6 +291,9 @@
         "wk:page":"East Sepik Province"
     },
     "wof:country":"PG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3b35cda0892c7063aedc3bdd0b140dc1",
     "wof:hierarchy":[
         {
@@ -310,7 +313,7 @@
         "eng",
         "hmo"
     ],
-    "wof:lastmodified":1566677979,
+    "wof:lastmodified":1582343934,
     "wof:name":"East Sepik",
     "wof:parent_id":85632347,
     "wof:placetype":"region",

--- a/data/856/765/23/85676523.geojson
+++ b/data/856/765/23/85676523.geojson
@@ -287,6 +287,9 @@
         "wk:page":"Madang Province"
     },
     "wof:country":"PG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6383a0f477883228c02101c2397219a2",
     "wof:hierarchy":[
         {
@@ -306,7 +309,7 @@
         "eng",
         "hmo"
     ],
-    "wof:lastmodified":1566677984,
+    "wof:lastmodified":1582343936,
     "wof:name":"Madang",
     "wof:parent_id":85632347,
     "wof:placetype":"region",

--- a/data/856/765/25/85676525.geojson
+++ b/data/856/765/25/85676525.geojson
@@ -288,6 +288,9 @@
         "wk:page":"Sandaun Province"
     },
     "wof:country":"PG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"04416c2f2aa69d28e60d415aa7632081",
     "wof:hierarchy":[
         {
@@ -307,7 +310,7 @@
         "eng",
         "hmo"
     ],
-    "wof:lastmodified":1566677985,
+    "wof:lastmodified":1582343937,
     "wof:name":"Sandaun",
     "wof:parent_id":85632347,
     "wof:placetype":"region",

--- a/data/856/765/31/85676531.geojson
+++ b/data/856/765/31/85676531.geojson
@@ -284,6 +284,9 @@
         "wk:page":"Chimbu Province"
     },
     "wof:country":"PG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"dbf9b3d842b181b513da68622fbbeb76",
     "wof:hierarchy":[
         {
@@ -303,7 +306,7 @@
         "eng",
         "hmo"
     ],
-    "wof:lastmodified":1566677982,
+    "wof:lastmodified":1582343935,
     "wof:name":"Chimbu",
     "wof:parent_id":85632347,
     "wof:placetype":"region",

--- a/data/856/765/33/85676533.geojson
+++ b/data/856/765/33/85676533.geojson
@@ -294,6 +294,9 @@
         "wk:page":"Eastern Highlands Province"
     },
     "wof:country":"PG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"295a090fa0ccfc4fc6debcd2689b2bdd",
     "wof:hierarchy":[
         {
@@ -313,7 +316,7 @@
         "eng",
         "hmo"
     ],
-    "wof:lastmodified":1566677978,
+    "wof:lastmodified":1582343934,
     "wof:name":"Eastern Highlands",
     "wof:parent_id":85632347,
     "wof:placetype":"region",

--- a/data/856/765/39/85676539.geojson
+++ b/data/856/765/39/85676539.geojson
@@ -278,6 +278,9 @@
         "wk:page":"Gulf Province"
     },
     "wof:country":"PG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"38347fe9fff1296d4551b2e7d3fce717",
     "wof:hierarchy":[
         {
@@ -297,7 +300,7 @@
         "eng",
         "hmo"
     ],
-    "wof:lastmodified":1566677983,
+    "wof:lastmodified":1582343935,
     "wof:name":"Gulf",
     "wof:parent_id":85632347,
     "wof:placetype":"region",

--- a/data/856/765/43/85676543.geojson
+++ b/data/856/765/43/85676543.geojson
@@ -274,6 +274,9 @@
         "wk:page":"Autonomous Region of Bougainville"
     },
     "wof:country":"PG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3f37c06b0422ee297a1f22de1092f819",
     "wof:hierarchy":[
         {
@@ -293,7 +296,7 @@
         "eng",
         "hmo"
     ],
-    "wof:lastmodified":1566677982,
+    "wof:lastmodified":1582343935,
     "wof:name":"North Solomons",
     "wof:parent_id":85632347,
     "wof:placetype":"region",

--- a/data/856/765/47/85676547.geojson
+++ b/data/856/765/47/85676547.geojson
@@ -290,6 +290,9 @@
         "wk:page":"Southern Highlands Province"
     },
     "wof:country":"PG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2939eeefc8aea0d06f6e0f40f45ee926",
     "wof:hierarchy":[
         {
@@ -309,7 +312,7 @@
         "eng",
         "hmo"
     ],
-    "wof:lastmodified":1566677985,
+    "wof:lastmodified":1582343936,
     "wof:name":"Southern Highlands",
     "wof:parent_id":85632347,
     "wof:placetype":"region",

--- a/data/856/765/51/85676551.geojson
+++ b/data/856/765/51/85676551.geojson
@@ -291,6 +291,9 @@
         "wk:page":"Western Highlands Province"
     },
     "wof:country":"PG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e895b2c32161e010863c46036a80c8c3",
     "wof:hierarchy":[
         {
@@ -310,7 +313,7 @@
         "eng",
         "hmo"
     ],
-    "wof:lastmodified":1566677978,
+    "wof:lastmodified":1582343933,
     "wof:name":"Western Highlands",
     "wof:parent_id":85632347,
     "wof:placetype":"region",

--- a/data/856/765/57/85676557.geojson
+++ b/data/856/765/57/85676557.geojson
@@ -231,6 +231,9 @@
         "wk:page":"Western Province (Papua New Guinea)"
     },
     "wof:country":"PG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1d9a98df710a39a51ecbf1337dc0d629",
     "wof:hierarchy":[
         {
@@ -250,7 +253,7 @@
         "eng",
         "hmo"
     ],
-    "wof:lastmodified":1566677977,
+    "wof:lastmodified":1582343933,
     "wof:name":"Western",
     "wof:parent_id":85632347,
     "wof:placetype":"region",

--- a/data/856/765/61/85676561.geojson
+++ b/data/856/765/61/85676561.geojson
@@ -293,6 +293,9 @@
         "wk:page":"Central Province (Papua New Guinea)"
     },
     "wof:country":"PG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5accaa4301c7b0d226801dd46f746fc1",
     "wof:hierarchy":[
         {
@@ -312,7 +315,7 @@
         "eng",
         "hmo"
     ],
-    "wof:lastmodified":1566677976,
+    "wof:lastmodified":1582343932,
     "wof:name":"Central",
     "wof:parent_id":85632347,
     "wof:placetype":"region",

--- a/data/856/765/65/85676565.geojson
+++ b/data/856/765/65/85676565.geojson
@@ -309,6 +309,9 @@
         "wk:page":"East New Britain Province"
     },
     "wof:country":"PG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c9e2a28647c3fa16def9aebd0fc2ffe6",
     "wof:hierarchy":[
         {
@@ -328,7 +331,7 @@
         "eng",
         "hmo"
     ],
-    "wof:lastmodified":1566677982,
+    "wof:lastmodified":1582343935,
     "wof:name":"East New Britain",
     "wof:parent_id":85632347,
     "wof:placetype":"region",

--- a/data/856/765/69/85676569.geojson
+++ b/data/856/765/69/85676569.geojson
@@ -287,6 +287,9 @@
         "wk:page":"Manus Province"
     },
     "wof:country":"PG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a832ed6726c8622484adceab233d2b91",
     "wof:hierarchy":[
         {
@@ -306,7 +309,7 @@
         "eng",
         "hmo"
     ],
-    "wof:lastmodified":1566677977,
+    "wof:lastmodified":1582343933,
     "wof:name":"Manus",
     "wof:parent_id":85632347,
     "wof:placetype":"region",

--- a/data/856/765/75/85676575.geojson
+++ b/data/856/765/75/85676575.geojson
@@ -281,6 +281,9 @@
         "wk:page":"Milne Bay Province"
     },
     "wof:country":"PG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"70c7cd14b52a46e014d9a15e397d7c7f",
     "wof:hierarchy":[
         {
@@ -300,7 +303,7 @@
         "eng",
         "hmo"
     ],
-    "wof:lastmodified":1566677980,
+    "wof:lastmodified":1582343934,
     "wof:name":"Milne Bay",
     "wof:parent_id":85632347,
     "wof:placetype":"region",

--- a/data/856/765/79/85676579.geojson
+++ b/data/856/765/79/85676579.geojson
@@ -290,6 +290,9 @@
         "wk:page":"Morobe Province"
     },
     "wof:country":"PG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8b33630a72da1bed80cfddcc9ac49e28",
     "wof:hierarchy":[
         {
@@ -309,7 +312,7 @@
         "eng",
         "hmo"
     ],
-    "wof:lastmodified":1566677984,
+    "wof:lastmodified":1582343936,
     "wof:name":"Morobe",
     "wof:parent_id":85632347,
     "wof:placetype":"region",

--- a/data/856/765/81/85676581.geojson
+++ b/data/856/765/81/85676581.geojson
@@ -225,6 +225,9 @@
         890444183
     ],
     "wof:country":"PG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3a6b36a71f5b7bf18cff6a11682dbc42",
     "wof:hierarchy":[
         {
@@ -244,7 +247,7 @@
         "eng",
         "hmo"
     ],
-    "wof:lastmodified":1566677981,
+    "wof:lastmodified":1582343935,
     "wof:name":"National Capital District",
     "wof:parent_id":85632347,
     "wof:placetype":"region",

--- a/data/856/765/87/85676587.geojson
+++ b/data/856/765/87/85676587.geojson
@@ -302,6 +302,9 @@
         "wk:page":"New Ireland Province"
     },
     "wof:country":"PG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4fccb1c7d3aed8b82574a60b9562b056",
     "wof:hierarchy":[
         {
@@ -321,7 +324,7 @@
         "eng",
         "hmo"
     ],
-    "wof:lastmodified":1566677978,
+    "wof:lastmodified":1582343934,
     "wof:name":"New Ireland",
     "wof:parent_id":85632347,
     "wof:placetype":"region",

--- a/data/856/765/95/85676595.geojson
+++ b/data/856/765/95/85676595.geojson
@@ -296,6 +296,9 @@
         "wk:page":"Oro Province"
     },
     "wof:country":"PG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7571653b98f0f581c763e2c438fe5952",
     "wof:hierarchy":[
         {
@@ -315,7 +318,7 @@
         "eng",
         "hmo"
     ],
-    "wof:lastmodified":1566677976,
+    "wof:lastmodified":1582343933,
     "wof:name":"Northern",
     "wof:parent_id":85632347,
     "wof:placetype":"region",

--- a/data/856/765/99/85676599.geojson
+++ b/data/856/765/99/85676599.geojson
@@ -304,6 +304,9 @@
         "wk:page":"West New Britain Province"
     },
     "wof:country":"PG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7596d3067e3fe52ecdfbd60e5857cc6c",
     "wof:hierarchy":[
         {
@@ -323,7 +326,7 @@
         "eng",
         "hmo"
     ],
-    "wof:lastmodified":1566677983,
+    "wof:lastmodified":1582343936,
     "wof:name":"West New Britain",
     "wof:parent_id":85632347,
     "wof:placetype":"region",

--- a/data/857/686/25/85768625.geojson
+++ b/data/857/686/25/85768625.geojson
@@ -78,6 +78,9 @@
         "wk:page":"Boroko"
     },
     "wof:country":"PG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7a736512649983d3bdf539bf8c33f0b3",
     "wof:hierarchy":[
         {
@@ -93,7 +96,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1534379399,
+    "wof:lastmodified":1582343932,
     "wof:name":"Boroko",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/686/29/85768629.geojson
+++ b/data/857/686/29/85768629.geojson
@@ -73,6 +73,9 @@
         "qs:id":894720
     },
     "wof:country":"PG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a2885bb8f256dcb7f96a5b3c75152ba6",
     "wof:hierarchy":[
         {
@@ -88,7 +91,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1534379399,
+    "wof:lastmodified":1582343931,
     "wof:name":"Gordon",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/686/33/85768633.geojson
+++ b/data/857/686/33/85768633.geojson
@@ -96,6 +96,9 @@
         "wk:page":"Hohola"
     },
     "wof:country":"PG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b4603e0ffe927ae2da77579d8dd10f37",
     "wof:hierarchy":[
         {
@@ -111,7 +114,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566677975,
+    "wof:lastmodified":1582343931,
     "wof:name":"Hohola",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/686/37/85768637.geojson
+++ b/data/857/686/37/85768637.geojson
@@ -93,6 +93,9 @@
         "qs_pg:id":478688
     },
     "wof:country":"PG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"683d65efc66f9bee04562e1d3826c7cd",
     "wof:hierarchy":[
         {
@@ -108,7 +111,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566677976,
+    "wof:lastmodified":1582343932,
     "wof:name":"Kaugere",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/686/43/85768643.geojson
+++ b/data/857/686/43/85768643.geojson
@@ -73,6 +73,9 @@
         "qs:id":478700
     },
     "wof:country":"PG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ac27f14bc3b8d9daa6f3d2dd273e44ba",
     "wof:hierarchy":[
         {
@@ -88,7 +91,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1534379399,
+    "wof:lastmodified":1582343932,
     "wof:name":"Koki",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/686/45/85768645.geojson
+++ b/data/857/686/45/85768645.geojson
@@ -96,6 +96,9 @@
         "wk:page":"Waigani"
     },
     "wof:country":"PG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"fb5fec948032db481671801a7402e04f",
     "wof:hierarchy":[
         {
@@ -111,7 +114,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566677975,
+    "wof:lastmodified":1582343931,
     "wof:name":"Waigani",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/890/422/413/890422413.geojson
+++ b/data/890/422/413/890422413.geojson
@@ -214,6 +214,9 @@
     },
     "wof:country":"PG",
     "wof:created":1469051442,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"8bf8ce1c26b35138fec659bf480df06f",
     "wof:hierarchy":[
         {
@@ -225,7 +228,7 @@
         }
     ],
     "wof:id":890422413,
-    "wof:lastmodified":1566678594,
+    "wof:lastmodified":1582343950,
     "wof:name":"Wewak",
     "wof:parent_id":1091705089,
     "wof:placetype":"locality",

--- a/data/890/432/095/890432095.geojson
+++ b/data/890/432/095/890432095.geojson
@@ -190,6 +190,9 @@
     },
     "wof:country":"PG",
     "wof:created":1469051928,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ec776314aa0f032edbac80274477bf12",
     "wof:hierarchy":[
         {
@@ -201,7 +204,7 @@
         }
     ],
     "wof:id":890432095,
-    "wof:lastmodified":1566678595,
+    "wof:lastmodified":1582343951,
     "wof:name":"Wabag",
     "wof:parent_id":1091704983,
     "wof:placetype":"locality",

--- a/data/890/432/099/890432099.geojson
+++ b/data/890/432/099/890432099.geojson
@@ -205,6 +205,9 @@
     },
     "wof:country":"PG",
     "wof:created":1469051928,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"aa55f1d272704684dc19810928c03f8f",
     "wof:hierarchy":[
         {
@@ -216,7 +219,7 @@
         }
     ],
     "wof:id":890432099,
-    "wof:lastmodified":1566678595,
+    "wof:lastmodified":1582343951,
     "wof:name":"Lorengau",
     "wof:parent_id":1091703475,
     "wof:placetype":"locality",

--- a/data/890/432/103/890432103.geojson
+++ b/data/890/432/103/890432103.geojson
@@ -205,6 +205,9 @@
     },
     "wof:country":"PG",
     "wof:created":1469051928,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"4fb074194681437a287e9a5d5656c8ae",
     "wof:hierarchy":[
         {
@@ -216,7 +219,7 @@
         }
     ],
     "wof:id":890432103,
-    "wof:lastmodified":1566678595,
+    "wof:lastmodified":1582343951,
     "wof:name":"Kimbe",
     "wof:parent_id":1091704547,
     "wof:placetype":"locality",

--- a/data/890/439/937/890439937.geojson
+++ b/data/890/439/937/890439937.geojson
@@ -214,6 +214,9 @@
     },
     "wof:country":"PG",
     "wof:created":1469052255,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e832f954d444ec402dc47544dafdcbb1",
     "wof:hierarchy":[
         {
@@ -225,7 +228,7 @@
         }
     ],
     "wof:id":890439937,
-    "wof:lastmodified":1566678594,
+    "wof:lastmodified":1582343951,
     "wof:name":"Goroka",
     "wof:parent_id":1091702429,
     "wof:placetype":"locality",

--- a/data/890/444/183/890444183.geojson
+++ b/data/890/444/183/890444183.geojson
@@ -502,6 +502,10 @@
     ],
     "wof:country":"PG",
     "wof:created":1469052454,
+    "wof:geom_alt":[
+        "unknown",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f0f40acbdd944d6cc4f29102ef652efd",
     "wof:hierarchy":[
         {
@@ -513,7 +517,7 @@
         }
     ],
     "wof:id":890444183,
-    "wof:lastmodified":1566678595,
+    "wof:lastmodified":1582343951,
     "wof:name":"Port Moresby",
     "wof:parent_id":1091703859,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.