### PR TITLE
pg concordances, placetype local, and more

### DIFF
--- a/data/109/170/191/9/1091701919.geojson
+++ b/data/109/170/191/9/1091701919.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.582486,
-    "geom:area_square_m":7092026695.131374,
+    "geom:area_square_m":7092026979.89909,
     "geom:bbox":"147.930367,-10.37125,149.66684,-9.742274",
     "geom:latitude":-10.049776,
     "geom:longitude":148.877816,
@@ -136,9 +136,10 @@
     "wof:concordances":{
         "hasc:id":"PG.CE.AB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PG",
     "wof:created":1473879807,
-    "wof:geomhash":"17b60053a1c474f462701baf79b1d514",
+    "wof:geomhash":"3799de328acab6f50e9ae3aac6042dc2",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -148,7 +149,7 @@
         }
     ],
     "wof:id":1091701919,
-    "wof:lastmodified":1636500484,
+    "wof:lastmodified":1695886753,
     "wof:name":"Abau",
     "wof:parent_id":85676561,
     "wof:placetype":"county",

--- a/data/109/170/195/5/1091701955.geojson
+++ b/data/109/170/195/5/1091701955.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.471327,
-    "geom:area_square_m":5818215447.171062,
+    "geom:area_square_m":5818215889.467996,
     "geom:bbox":"141.656118,-3.711641,143.09055,-2.958977",
     "geom:latitude":-3.324433,
     "geom:longitude":142.161101,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"PG.SA.AL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PG",
     "wof:created":1473879808,
-    "wof:geomhash":"d823473c18e8baf0933b42b76b4ba141",
+    "wof:geomhash":"37c1fb52d1d1983ec97ae928a67b107a",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091701955,
-    "wof:lastmodified":1627522499,
+    "wof:lastmodified":1695886138,
     "wof:name":"Aitape-Lumi",
     "wof:parent_id":85676525,
     "wof:placetype":"county",

--- a/data/109/170/200/1/1091702001.geojson
+++ b/data/109/170/200/1/1091702001.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.660948,
-    "geom:area_square_m":8045192714.679337,
+    "geom:area_square_m":8045192019.202955,
     "geom:bbox":"148.965223,-10.704611,151.04039,-9.59125",
     "geom:latitude":-10.131397,
     "geom:longitude":149.910295,
@@ -138,9 +138,10 @@
     "wof:concordances":{
         "hasc:id":"PG.MB.AL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PG",
     "wof:created":1473879809,
-    "wof:geomhash":"a695cd9d9de85a18209466dc007d8704",
+    "wof:geomhash":"0d02a2a352364198073f8644b2b602cb",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -150,7 +151,7 @@
         }
     ],
     "wof:id":1091702001,
-    "wof:lastmodified":1636500485,
+    "wof:lastmodified":1695886754,
     "wof:name":"Alotau",
     "wof:parent_id":85676575,
     "wof:placetype":"county",

--- a/data/109/170/205/3/1091702053.geojson
+++ b/data/109/170/205/3/1091702053.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.216134,
-    "geom:area_square_m":14994279098.596479,
+    "geom:area_square_m":14994278660.582716,
     "geom:bbox":"141.335071,-5.042559,143.075539,-3.403964",
     "geom:latitude":-4.346,
     "geom:longitude":142.30768,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"PG.ES.AT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PG",
     "wof:created":1473879811,
-    "wof:geomhash":"463f5bf2ffa7440dee84d585afd05e9a",
+    "wof:geomhash":"1279b119c41a15fed5a66f692aea32d2",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091702053,
-    "wof:lastmodified":1627522499,
+    "wof:lastmodified":1695886138,
     "wof:name":"Ambunti-Dreikikir",
     "wof:parent_id":85676519,
     "wof:placetype":"county",

--- a/data/109/170/205/7/1091702057.geojson
+++ b/data/109/170/205/7/1091702057.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.180504,
-    "geom:area_square_m":2219562747.164715,
+    "geom:area_square_m":2219563214.871304,
     "geom:bbox":"144.273802,-6.389439,144.799087,-5.746205",
     "geom:latitude":-6.040753,
     "geom:longitude":144.546086,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"PG.JI.SW"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PG",
     "wof:created":1473879812,
-    "wof:geomhash":"7e4e5188eb5b12df81e5a814ae7b4e9f",
+    "wof:geomhash":"f431edf73c20c193cb0173020c824a54",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091702057,
-    "wof:lastmodified":1627522499,
+    "wof:lastmodified":1695886138,
     "wof:name":"Anglimp-South Waghi",
     "wof:parent_id":1108805613,
     "wof:placetype":"county",

--- a/data/109/170/205/9/1091702059.geojson
+++ b/data/109/170/205/9/1091702059.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.609542,
-    "geom:area_square_m":19840539750.340736,
+    "geom:area_square_m":19840539668.019745,
     "geom:bbox":"142.825834,-5.158184,144.577984,-3.77875",
     "geom:latitude":-4.502826,
     "geom:longitude":143.76413,
@@ -84,9 +84,10 @@
     "wof:concordances":{
         "hasc:id":"PG.ES.AN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PG",
     "wof:created":1473879814,
-    "wof:geomhash":"92b79fc9552d8f6df7274cea0389c0f0",
+    "wof:geomhash":"00ac211500dec21bd52fb36573836a5e",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -96,7 +97,7 @@
         }
     ],
     "wof:id":1091702059,
-    "wof:lastmodified":1627522499,
+    "wof:lastmodified":1695886138,
     "wof:name":"Angoram",
     "wof:parent_id":85676519,
     "wof:placetype":"county",

--- a/data/109/170/206/3/1091702063.geojson
+++ b/data/109/170/206/3/1091702063.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.302633,
-    "geom:area_square_m":3731155995.26279,
+    "geom:area_square_m":3731155332.30636,
     "geom:bbox":"144.569217,-4.687061,145.482455,-4.000548",
     "geom:latitude":-4.383342,
     "geom:longitude":144.921352,
@@ -72,9 +72,10 @@
     "wof:concordances":{
         "hasc:id":"PG.MD.BG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PG",
     "wof:created":1473879816,
-    "wof:geomhash":"991d714dd6da57b81624471c15c98556",
+    "wof:geomhash":"ff53a97a6f4c8c5e410498e6dcace14a",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -84,7 +85,7 @@
         }
     ],
     "wof:id":1091702063,
-    "wof:lastmodified":1627522499,
+    "wof:lastmodified":1695886139,
     "wof:name":"Bogia",
     "wof:parent_id":85676523,
     "wof:placetype":"county",

--- a/data/109/170/209/1/1091702091.geojson
+++ b/data/109/170/209/1/1091702091.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.722511,
-    "geom:area_square_m":8858621560.969917,
+    "geom:area_square_m":8858621560.970493,
     "geom:bbox":"146.293239017,-8.03241472541,147.568467426,-6.72921681754",
     "geom:latitude":-7.438959,
     "geom:longitude":146.817133,
@@ -87,9 +87,10 @@
     "wof:concordances":{
         "hasc:id":"PG.MR.BL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PG",
     "wof:created":1473879817,
-    "wof:geomhash":"7ef1ac1e1003f01351c8b2e1a7ae5814",
+    "wof:geomhash":"07b025b4f9ff4abe7bfdbf2db06b2f79",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -99,7 +100,7 @@
         }
     ],
     "wof:id":1091702091,
-    "wof:lastmodified":1566678546,
+    "wof:lastmodified":1695886604,
     "wof:name":"Bulolo",
     "wof:parent_id":85676579,
     "wof:placetype":"county",

--- a/data/109/170/212/1/1091702121.geojson
+++ b/data/109/170/212/1/1091702121.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.243887,
-    "geom:area_square_m":2998290294.042871,
+    "geom:area_square_m":2998290382.977555,
     "geom:bbox":"154.918953,-6.545665,155.909384,-5.727083",
     "geom:latitude":-6.158988,
     "geom:longitude":155.382615,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"PG.NS.KI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PG",
     "wof:created":1473879818,
-    "wof:geomhash":"4c6f8d160c3f9e2c64441e03a0b02f0a",
+    "wof:geomhash":"e75ae61d6ff6387fc8c8881f2320e20b",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091702121,
-    "wof:lastmodified":1627522499,
+    "wof:lastmodified":1695886139,
     "wof:name":"Central Bougainville",
     "wof:parent_id":85676543,
     "wof:placetype":"county",

--- a/data/109/170/216/3/1091702163.geojson
+++ b/data/109/170/216/3/1091702163.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.0473,
-    "geom:area_square_m":581449587.087238,
+    "geom:area_square_m":581449313.498833,
     "geom:bbox":"145.03977,-6.352713,145.270645,-5.992811",
     "geom:latitude":-6.204655,
     "geom:longitude":145.153122,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"PG.CH.CH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PG",
     "wof:created":1473879820,
-    "wof:geomhash":"ee82b1029f68f710a27fb2d56ca1c09c",
+    "wof:geomhash":"c0629644275e6bed1b6fca85b3c2df37",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091702163,
-    "wof:lastmodified":1627522499,
+    "wof:lastmodified":1695886139,
     "wof:name":"Chuave",
     "wof:parent_id":85676531,
     "wof:placetype":"county",

--- a/data/109/170/221/1/1091702211.geojson
+++ b/data/109/170/221/1/1091702211.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.048984,
-    "geom:area_square_m":602403443.483849,
+    "geom:area_square_m":602403711.292721,
     "geom:bbox":"145.122912,-6.130977,145.38941,-5.852974",
     "geom:latitude":-5.978425,
     "geom:longitude":145.238541,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"PG.EH.DA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PG",
     "wof:created":1473879821,
-    "wof:geomhash":"b21961a659ea48c44e92a9c0354c3073",
+    "wof:geomhash":"6bb7641f86ceae557bbe99bf47911e5f",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091702211,
-    "wof:lastmodified":1627522499,
+    "wof:lastmodified":1695886139,
     "wof:name":"Daulo",
     "wof:parent_id":85676533,
     "wof:placetype":"county",

--- a/data/109/170/225/1/1091702251.geojson
+++ b/data/109/170/225/1/1091702251.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.06409,
-    "geom:area_square_m":788647289.389801,
+    "geom:area_square_m":788647414.786581,
     "geom:bbox":"144.191935,-5.79061,144.514772,-5.51311",
     "geom:latitude":-5.645257,
     "geom:longitude":144.351745,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"PG.WL.DE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PG",
     "wof:created":1473879823,
-    "wof:geomhash":"f6f3bc46f95557806946a4317b5c51ae",
+    "wof:geomhash":"6ac2153f6af47ef544d26a03f1cfa935",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091702251,
-    "wof:lastmodified":1627522499,
+    "wof:lastmodified":1695886139,
     "wof:name":"Dei",
     "wof:parent_id":85676551,
     "wof:placetype":"county",

--- a/data/109/170/229/9/1091702299.geojson
+++ b/data/109/170/229/9/1091702299.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.191075,
-    "geom:area_square_m":2328818240.028615,
+    "geom:area_square_m":2328819373.329477,
     "geom:bbox":"150.422913,-10.193778,151.294586,-9.262917",
     "geom:latitude":-9.709528,
     "geom:longitude":150.824807,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"PG.MB.EA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PG",
     "wof:created":1473879825,
-    "wof:geomhash":"da2f27de5a236d007ed8a22b31e14b1c",
+    "wof:geomhash":"94f159747515d68d3977069f833f8b64",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091702299,
-    "wof:lastmodified":1627522499,
+    "wof:lastmodified":1695886139,
     "wof:name":"Esa'ala",
     "wof:parent_id":85676575,
     "wof:placetype":"county",

--- a/data/109/170/235/1/1091702351.geojson
+++ b/data/109/170/235/1/1091702351.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.19914,
-    "geom:area_square_m":2446504629.901568,
+    "geom:area_square_m":2446504629.901717,
     "geom:bbox":"147.135313338,-6.71429360116,147.862976074,-6.33615593506",
     "geom:latitude":-6.514773,
     "geom:longitude":147.539417,
@@ -90,9 +90,10 @@
     "wof:concordances":{
         "hasc:id":"PG.MR.FI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PG",
     "wof:created":1473879826,
-    "wof:geomhash":"9502f891ce33812c4f31560e1d08c4f2",
+    "wof:geomhash":"34bb10b653a515bf1d37907d09490145",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -102,7 +103,7 @@
         }
     ],
     "wof:id":1091702351,
-    "wof:lastmodified":1566678537,
+    "wof:lastmodified":1695886604,
     "wof:name":"Finschhafen",
     "wof:parent_id":85676579,
     "wof:placetype":"county",

--- a/data/109/170/239/7/1091702397.geojson
+++ b/data/109/170/239/7/1091702397.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.272522,
-    "geom:area_square_m":3359489041.322471,
+    "geom:area_square_m":3359489041.322322,
     "geom:bbox":"151.487075806,-4.9815355639,152.212130331,-4.187055588",
     "geom:latitude":-4.478287,
     "geom:longitude":151.823425,
@@ -246,9 +246,10 @@
     "wof:concordances":{
         "hasc:id":"PG.EN.GZ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PG",
     "wof:created":1473879827,
-    "wof:geomhash":"eb837e47f7f2e048e345d9d133e4c694",
+    "wof:geomhash":"7ecb4710c027c946c2082d3c7d2f3a33",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -258,7 +259,7 @@
         }
     ],
     "wof:id":1091702397,
-    "wof:lastmodified":1566678548,
+    "wof:lastmodified":1695886605,
     "wof:name":"Gazelle",
     "wof:parent_id":85676565,
     "wof:placetype":"county",

--- a/data/109/170/242/5/1091702425.geojson
+++ b/data/109/170/242/5/1091702425.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.642457,
-    "geom:area_square_m":7859522561.945793,
+    "geom:area_square_m":7859521877.237886,
     "geom:bbox":"146.379146,-8.881648,147.650364,-7.768499",
     "geom:latitude":-8.364141,
     "geom:longitude":147.005221,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"PG.CE.GL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PG",
     "wof:created":1473879829,
-    "wof:geomhash":"198db33ce09081031591fcb26ee94d36",
+    "wof:geomhash":"e83720b1efe163c29a11bbc9093d90da",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091702425,
-    "wof:lastmodified":1627522500,
+    "wof:lastmodified":1695886139,
     "wof:name":"Goilala",
     "wof:parent_id":85676561,
     "wof:placetype":"county",

--- a/data/109/170/242/9/1091702429.geojson
+++ b/data/109/170/242/9/1091702429.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.028161,
-    "geom:area_square_m":346281751.264114,
+    "geom:area_square_m":346281402.968815,
     "geom:bbox":"145.258228,-6.149019,145.478215,-5.895716",
     "geom:latitude":-6.036037,
     "geom:longitude":145.382391,
@@ -141,9 +141,10 @@
     "wof:concordances":{
         "hasc:id":"PG.EH.GK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PG",
     "wof:created":1473879830,
-    "wof:geomhash":"aaf72d2d8bba82cd82ff7ea630bd2767",
+    "wof:geomhash":"8d6dad641c1432348a328e8df443e1ac",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -153,7 +154,7 @@
         }
     ],
     "wof:id":1091702429,
-    "wof:lastmodified":1636500483,
+    "wof:lastmodified":1695886753,
     "wof:name":"Goroka",
     "wof:parent_id":85676533,
     "wof:placetype":"county",

--- a/data/109/170/243/1/1091702431.geojson
+++ b/data/109/170/243/1/1091702431.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.057349,
-    "geom:area_square_m":704990669.946293,
+    "geom:area_square_m":704990454.685048,
     "geom:bbox":"144.6814,-6.350216,144.979757,-6.031337",
     "geom:latitude":-6.196153,
     "geom:longitude":144.834219,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"PG.CH.GM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PG",
     "wof:created":1473879832,
-    "wof:geomhash":"d9cbdf2d7af3bb2b52690afc9eae8868",
+    "wof:geomhash":"3c97e4f04a424ac1d6c026ef78615705",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091702431,
-    "wof:lastmodified":1627522500,
+    "wof:lastmodified":1695886140,
     "wof:name":"Gumine",
     "wof:parent_id":85676531,
     "wof:placetype":"county",

--- a/data/109/170/243/3/1091702433.geojson
+++ b/data/109/170/243/3/1091702433.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.085007,
-    "geom:area_square_m":1044984296.649574,
+    "geom:area_square_m":1044983879.191532,
     "geom:bbox":"145.474602,-6.443498,145.820457,-5.97395",
     "geom:latitude":-6.199638,
     "geom:longitude":145.653451,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"PG.EH.HE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PG",
     "wof:created":1473879833,
-    "wof:geomhash":"4178e209a26ee1d5ff760b59b8f10a87",
+    "wof:geomhash":"dbf57708422de39c3f7cdb7ebc85814c",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091702433,
-    "wof:lastmodified":1627522500,
+    "wof:lastmodified":1695886140,
     "wof:name":"Henganofi",
     "wof:parent_id":85676533,
     "wof:placetype":"county",

--- a/data/109/170/245/3/1091702453.geojson
+++ b/data/109/170/245/3/1091702453.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.465644,
-    "geom:area_square_m":5713204324.258113,
+    "geom:area_square_m":5713204324.255614,
     "geom:bbox":"146.179839217,-8.01050609418,147.957077026,-6.32735911904",
     "geom:latitude":-7.118184,
     "geom:longitude":146.936096,
@@ -75,9 +75,10 @@
     "wof:concordances":{
         "hasc:id":"PG.MR.HG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PG",
     "wof:created":1473879835,
-    "wof:geomhash":"030575ed4d6a0f9095aec24bcb22b088",
+    "wof:geomhash":"48726aa71e6a0c0985dd9f02cb52ce49",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -87,7 +88,7 @@
         }
     ],
     "wof:id":1091702453,
-    "wof:lastmodified":1566678533,
+    "wof:lastmodified":1695886604,
     "wof:name":"Huon",
     "wof:parent_id":85676579,
     "wof:placetype":"county",

--- a/data/109/170/249/1/1091702491.geojson
+++ b/data/109/170/249/1/1091702491.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.17442,
-    "geom:area_square_m":2143369703.81905,
+    "geom:area_square_m":2143369411.428944,
     "geom:bbox":"143.79164,-6.646423,144.564606,-6.160912",
     "geom:latitude":-6.381949,
     "geom:longitude":144.224091,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"PG.SL.IP"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PG",
     "wof:created":1473879836,
-    "wof:geomhash":"a3f87489fba805b3ee28ee4b3ac25504",
+    "wof:geomhash":"9c3330d57f1c7556e5ae130be4eb3431",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091702491,
-    "wof:lastmodified":1627522500,
+    "wof:lastmodified":1695886140,
     "wof:name":"Ialibu-Pangia",
     "wof:parent_id":85676547,
     "wof:placetype":"county",

--- a/data/109/170/253/1/1091702531.geojson
+++ b/data/109/170/253/1/1091702531.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.057478,
-    "geom:area_square_m":12903301109.256325,
+    "geom:area_square_m":12903301433.712889,
     "geom:bbox":"147.959445,-9.975395,149.439021,-8.120542",
     "geom:latitude":-9.313622,
     "geom:longitude":148.612703,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"PG.NO.PP"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PG",
     "wof:created":1473879838,
-    "wof:geomhash":"3a9204427cf64424c4b1aa4dbd496b39",
+    "wof:geomhash":"ec5040ef58e98b46c3c7e7e8f3055947",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091702531,
-    "wof:lastmodified":1627522500,
+    "wof:lastmodified":1695886140,
     "wof:name":"Ijivitari",
     "wof:parent_id":85676595,
     "wof:placetype":"county",

--- a/data/109/170/257/3/1091702573.geojson
+++ b/data/109/170/257/3/1091702573.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.105418,
-    "geom:area_square_m":1295978790.666603,
+    "geom:area_square_m":1295979626.127342,
     "geom:bbox":"143.512899,-6.315289,144.232633,-5.998613",
     "geom:latitude":-6.161072,
     "geom:longitude":143.909272,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"PG.SL.IB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PG",
     "wof:created":1473879840,
-    "wof:geomhash":"5c65b36036b2ba507af3e7349b2dc396",
+    "wof:geomhash":"0576fe966bb98160d63def63b3baa8b0",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091702573,
-    "wof:lastmodified":1627522500,
+    "wof:lastmodified":1695886140,
     "wof:name":"Imbonggu",
     "wof:parent_id":85676547,
     "wof:placetype":"county",

--- a/data/109/170/260/9/1091702609.geojson
+++ b/data/109/170/260/9/1091702609.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.177204,
-    "geom:area_square_m":2180903692.45399,
+    "geom:area_square_m":2180903692.452843,
     "geom:bbox":"144.287324576,-5.81047503687,145.023082204,-5.21682882075",
     "geom:latitude":-5.546316,
     "geom:longitude":144.625358,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"PG.JI.JI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PG",
     "wof:created":1473879841,
-    "wof:geomhash":"d1b26a9763d1270ae68e228d1dee5821",
+    "wof:geomhash":"241ff292cd66a9a89d5601d62a437a79",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1091702609,
-    "wof:lastmodified":1566678537,
+    "wof:lastmodified":1695886604,
     "wof:name":"Jimi",
     "wof:parent_id":1108805613,
     "wof:placetype":"county",

--- a/data/109/170/264/7/1091702647.geojson
+++ b/data/109/170/264/7/1091702647.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.292448,
-    "geom:area_square_m":3595261431.473186,
+    "geom:area_square_m":3595261460.170765,
     "geom:bbox":"146.503356,-6.417619,147.588176,-5.883242",
     "geom:latitude":-6.163856,
     "geom:longitude":147.026609,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"PG.MR.KW"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PG",
     "wof:created":1473879843,
-    "wof:geomhash":"4da2ee68b61862189db49bb5b0964906",
+    "wof:geomhash":"fa288d855a365acb4b5e0cfea6e80f43",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091702647,
-    "wof:lastmodified":1627522500,
+    "wof:lastmodified":1695886140,
     "wof:name":"Kabwum",
     "wof:parent_id":85676579,
     "wof:placetype":"county",

--- a/data/109/170/266/5/1091702665.geojson
+++ b/data/109/170/266/5/1091702665.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.294241,
-    "geom:area_square_m":3614207270.782364,
+    "geom:area_square_m":3614206788.762508,
     "geom:bbox":"143.616622,-6.828902,144.687738,-6.240366",
     "geom:latitude":-6.602779,
     "geom:longitude":144.007304,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"PG.SL.KG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PG",
     "wof:created":1473879844,
-    "wof:geomhash":"dc266305ec3b90db081ee3022746e460",
+    "wof:geomhash":"24f36b41c64174ff67ed288189c6abdd",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091702665,
-    "wof:lastmodified":1627522500,
+    "wof:lastmodified":1695886140,
     "wof:name":"Kagua-Erave",
     "wof:parent_id":85676547,
     "wof:placetype":"county",

--- a/data/109/170/271/1/1091702711.geojson
+++ b/data/109/170/271/1/1091702711.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.158546,
-    "geom:area_square_m":1948592069.102956,
+    "geom:area_square_m":1948591728.35046,
     "geom:bbox":"145.609791,-6.518839,146.134208,-5.976505",
     "geom:latitude":-6.303753,
     "geom:longitude":145.90373,
@@ -84,9 +84,10 @@
     "wof:concordances":{
         "hasc:id":"PG.EH.KA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PG",
     "wof:created":1473879845,
-    "wof:geomhash":"ece73ccd1bbba241ceb4224253c1a529",
+    "wof:geomhash":"64ec478c97ca967a11fa438ac6e02ae5",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -96,7 +97,7 @@
         }
     ],
     "wof:id":1091702711,
-    "wof:lastmodified":1627522500,
+    "wof:lastmodified":1695886140,
     "wof:name":"Kainantu",
     "wof:parent_id":85676533,
     "wof:placetype":"county",

--- a/data/109/170/275/1/1091702751.geojson
+++ b/data/109/170/275/1/1091702751.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.792796,
-    "geom:area_square_m":9683086625.981245,
+    "geom:area_square_m":9683087325.366261,
     "geom:bbox":"146.374442,-9.680496,147.859918,-8.102623",
     "geom:latitude":-8.96758,
     "geom:longitude":147.068314,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"PG.CE.KH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PG",
     "wof:created":1473879847,
-    "wof:geomhash":"cf4399098d53d03de88b8993a7d472db",
+    "wof:geomhash":"8e230024822d3fba0d63483c0875be50",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091702751,
-    "wof:lastmodified":1627522500,
+    "wof:lastmodified":1695886141,
     "wof:name":"Kairuku-Hiri",
     "wof:parent_id":85676561,
     "wof:placetype":"county",

--- a/data/109/170/278/5/1091702785.geojson
+++ b/data/109/170/278/5/1091702785.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.165643,
-    "geom:area_square_m":2037923805.482503,
+    "geom:area_square_m":2037923632.002974,
     "geom:bbox":"142.983062,-5.978645,143.826999,-5.518929",
     "geom:latitude":-5.743565,
     "geom:longitude":143.407152,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"PG.EG.KD"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PG",
     "wof:created":1473879848,
-    "wof:geomhash":"0e99f8c307bde94fdf6118cde741c18b",
+    "wof:geomhash":"956bc237d612ed41a789cecae416b2eb",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091702785,
-    "wof:lastmodified":1627522500,
+    "wof:lastmodified":1695886141,
     "wof:name":"Kandep",
     "wof:parent_id":85676513,
     "wof:placetype":"county",

--- a/data/109/170/282/7/1091702827.geojson
+++ b/data/109/170/282/7/1091702827.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.084307,
-    "geom:area_square_m":13337303543.864185,
+    "geom:area_square_m":13337304216.267044,
     "geom:bbox":"148.306229,-6.317945,150.781219,-4.617084",
     "geom:latitude":-5.867853,
     "geom:longitude":149.488326,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"PG.WN.KG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PG",
     "wof:created":1473879850,
-    "wof:geomhash":"4721c3e1a65d5617d8090f449f2d2485",
+    "wof:geomhash":"9a332417e164864bf7b9030f6e0a21a8",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091702827,
-    "wof:lastmodified":1627522501,
+    "wof:lastmodified":1695886141,
     "wof:name":"Kandrian-Gloucester",
     "wof:parent_id":85676599,
     "wof:placetype":"county",

--- a/data/109/170/287/3/1091702873.geojson
+++ b/data/109/170/287/3/1091702873.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.287214,
-    "geom:area_square_m":3528283209.766542,
+    "geom:area_square_m":3528283732.841202,
     "geom:bbox":"144.423151,-6.871516,145.348156,-6.188351",
     "geom:latitude":-6.546763,
     "geom:longitude":144.885975,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"PG.CH.KM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PG",
     "wof:created":1473879851,
-    "wof:geomhash":"ac222e1333c706df6d793ef4d399c3d4",
+    "wof:geomhash":"174fadb73316e5142bb23ad2554150d0",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091702873,
-    "wof:lastmodified":1627522501,
+    "wof:lastmodified":1695886141,
     "wof:name":"Karimui-Nomane",
     "wof:parent_id":85676531,
     "wof:placetype":"county",

--- a/data/109/170/291/7/1091702917.geojson
+++ b/data/109/170/291/7/1091702917.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.241841,
-    "geom:area_square_m":2987404648.457971,
+    "geom:area_square_m":2987404312.274728,
     "geom:bbox":"149.505386,-3.090595,151.553476,-1.315444",
     "geom:latitude":-2.528001,
     "geom:longitude":150.535724,
@@ -141,9 +141,10 @@
     "wof:concordances":{
         "hasc:id":"PG.NI.KV"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PG",
     "wof:created":1473879853,
-    "wof:geomhash":"3f81907a4fddb8cc56f08772dee2c181",
+    "wof:geomhash":"f0070168ba3df0f8fe968f7f3f0b1441",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -153,7 +154,7 @@
         }
     ],
     "wof:id":1091702917,
-    "wof:lastmodified":1636500485,
+    "wof:lastmodified":1695886754,
     "wof:name":"Kavieng",
     "wof:parent_id":85676587,
     "wof:placetype":"county",

--- a/data/109/170/295/5/1091702955.geojson
+++ b/data/109/170/295/5/1091702955.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.593728,
-    "geom:area_square_m":7274000979.0334,
+    "geom:area_square_m":7274001502.760832,
     "geom:bbox":"145.603104,-8.58276,146.652965,-7.128396",
     "geom:latitude":-7.77385,
     "geom:longitude":146.065333,
@@ -135,9 +135,10 @@
     "wof:concordances":{
         "hasc:id":"PG.GU.KM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PG",
     "wof:created":1473879855,
-    "wof:geomhash":"7ac0ab2bed376cf5458fbb4b9c870f66",
+    "wof:geomhash":"bbc9b05bbb2bee6cb4e939c1dac4da69",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -147,7 +148,7 @@
         }
     ],
     "wof:id":1091702955,
-    "wof:lastmodified":1636500483,
+    "wof:lastmodified":1695886753,
     "wof:name":"Kerema",
     "wof:parent_id":85676539,
     "wof:placetype":"county",

--- a/data/109/170/300/3/1091703003.geojson
+++ b/data/109/170/300/3/1091703003.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.049102,
-    "geom:area_square_m":603908878.069704,
+    "geom:area_square_m":603908403.382771,
     "geom:bbox":"144.694197,-6.094182,145.024862,-5.775556",
     "geom:latitude":-5.924442,
     "geom:longitude":144.869896,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"PG.CH.KG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PG",
     "wof:created":1473879856,
-    "wof:geomhash":"112627997162168be4ee428a90ea1b96",
+    "wof:geomhash":"37c92ad772f3879e4095fc7880244fa5",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091703003,
-    "wof:lastmodified":1627522501,
+    "wof:lastmodified":1695886142,
     "wof:name":"Kerowagi",
     "wof:parent_id":85676531,
     "wof:placetype":"county",

--- a/data/109/170/304/9/1091703049.geojson
+++ b/data/109/170/304/9/1091703049.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.26497,
-    "geom:area_square_m":27780980281.435959,
+    "geom:area_square_m":27780981233.942924,
     "geom:bbox":"142.990373,-7.95268,145.716977,-6.699639",
     "geom:latitude":-7.274962,
     "geom:longitude":144.46924,
@@ -72,9 +72,10 @@
     "wof:concordances":{
         "hasc:id":"PG.GU.KK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PG",
     "wof:created":1473879858,
-    "wof:geomhash":"f4199ff929c45364c4eb1c5a57229ea5",
+    "wof:geomhash":"8a60b5abb4655eb90fc05023b1777285",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -84,7 +85,7 @@
         }
     ],
     "wof:id":1091703049,
-    "wof:lastmodified":1627522501,
+    "wof:lastmodified":1695886142,
     "wof:name":"Kikori",
     "wof:parent_id":85676539,
     "wof:placetype":"county",

--- a/data/109/170/308/3/1091703083.geojson
+++ b/data/109/170/308/3/1091703083.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.089839,
-    "geom:area_square_m":1096930944.963222,
+    "geom:area_square_m":1096931403.386633,
     "geom:bbox":"150.094559,-9.524611,151.358749,-8.327056",
     "geom:latitude":-9.079189,
     "geom:longitude":150.53333,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"PG.MB.KG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PG",
     "wof:created":1473879859,
-    "wof:geomhash":"b4ecb1553bd17b01899dd8bbcbe2016d",
+    "wof:geomhash":"bfd5bbdce2fedc5ecf6b0e9df570d723",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091703083,
-    "wof:lastmodified":1627522501,
+    "wof:lastmodified":1695886142,
     "wof:name":"Kiriwina-Goodenough",
     "wof:parent_id":85676575,
     "wof:placetype":"county",

--- a/data/109/170/313/1/1091703131.geojson
+++ b/data/109/170/313/1/1091703131.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.032407,
-    "geom:area_square_m":399555293.125492,
+    "geom:area_square_m":399555293.125429,
     "geom:bbox":"152.156980369,-4.5270594873,152.497909546,-4.118750095",
     "geom:latitude":-4.361817,
     "geom:longitude":152.308976,
@@ -120,9 +120,10 @@
     "wof:concordances":{
         "hasc:id":"PG.EN.KO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PG",
     "wof:created":1473879861,
-    "wof:geomhash":"d1cbce0445535b1ad9a65c07a5e429c8",
+    "wof:geomhash":"7c5960c962048421a7befecc5ae851a3",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -132,7 +133,7 @@
         }
     ],
     "wof:id":1091703131,
-    "wof:lastmodified":1566678540,
+    "wof:lastmodified":1695886604,
     "wof:name":"Kokopo",
     "wof:parent_id":85676565,
     "wof:placetype":"county",

--- a/data/109/170/317/9/1091703179.geojson
+++ b/data/109/170/317/9/1091703179.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.268426,
-    "geom:area_square_m":3300650773.970966,
+    "geom:area_square_m":3300650189.56789,
     "geom:bbox":"142.625335,-6.358051,143.413512,-5.715423",
     "geom:latitude":-6.050055,
     "geom:longitude":143.030362,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"PG.HE.KM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PG",
     "wof:created":1473879862,
-    "wof:geomhash":"5641a9152b4f926fe866840aecb80c52",
+    "wof:geomhash":"27c4ab1602c50d57267ddaed848ae99d",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091703179,
-    "wof:lastmodified":1627522501,
+    "wof:lastmodified":1695886142,
     "wof:name":"Komo-Magarima",
     "wof:parent_id":1108805615,
     "wof:placetype":"county",

--- a/data/109/170/320/7/1091703207.geojson
+++ b/data/109/170/320/7/1091703207.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.238717,
-    "geom:area_square_m":2939347411.447624,
+    "geom:area_square_m":2939347527.988312,
     "geom:bbox":"143.535821,-5.506104,144.248473,-5.008059",
     "geom:latitude":-5.25869,
     "geom:longitude":143.881738,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"PG.EG.KM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PG",
     "wof:created":1473879863,
-    "wof:geomhash":"b169f7582934be0792b6a5844d8abdac",
+    "wof:geomhash":"62b673691c301b680c0e40df1a8c98e6",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091703207,
-    "wof:lastmodified":1627522501,
+    "wof:lastmodified":1695886142,
     "wof:name":"Kompiam-Ambum",
     "wof:parent_id":85676513,
     "wof:placetype":"county",

--- a/data/109/170/324/7/1091703247.geojson
+++ b/data/109/170/324/7/1091703247.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.446612,
-    "geom:area_square_m":5497592852.85866,
+    "geom:area_square_m":5497592993.383327,
     "geom:bbox":"142.06756,-5.921951,142.845298,-4.945202",
     "geom:latitude":-5.432783,
     "geom:longitude":142.513334,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"PG.HE.KR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PG",
     "wof:created":1473879865,
-    "wof:geomhash":"12d0867db42b86a9aaa548c678e3f1aa",
+    "wof:geomhash":"12a03837eb4b9d667c51821f1249708b",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091703247,
-    "wof:lastmodified":1627522501,
+    "wof:lastmodified":1695886142,
     "wof:name":"Koroba-Kopiago",
     "wof:parent_id":1108805615,
     "wof:placetype":"county",

--- a/data/109/170/330/9/1091703309.geojson
+++ b/data/109/170/330/9/1091703309.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.036883,
-    "geom:area_square_m":453630489.422182,
+    "geom:area_square_m":453630813.442876,
     "geom:bbox":"144.8529,-6.043981,145.16477,-5.775735",
     "geom:latitude":-5.915646,
     "geom:longitude":145.03661,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"PG.CH.KD"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PG",
     "wof:created":1473879867,
-    "wof:geomhash":"8c8345f5aa242b1699d72fbed69f83dd",
+    "wof:geomhash":"e3ae0fba2f8c89e4cce9a7e9ed962004",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091703309,
-    "wof:lastmodified":1627522501,
+    "wof:lastmodified":1695886142,
     "wof:name":"Kundiawa-Gembogl",
     "wof:parent_id":85676531,
     "wof:placetype":"county",

--- a/data/109/170/333/5/1091703335.geojson
+++ b/data/109/170/333/5/1091703335.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.011633,
-    "geom:area_square_m":142870327.86636,
+    "geom:area_square_m":142870335.452798,
     "geom:bbox":"146.953077,-6.748421,147.08908,-6.601429",
     "geom:latitude":-6.684016,
     "geom:longitude":147.010444,
@@ -147,9 +147,10 @@
     "wof:concordances":{
         "hasc:id":"PG.MR.LA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PG",
     "wof:created":1473879868,
-    "wof:geomhash":"e33ade09cb402b353a15785b22688546",
+    "wof:geomhash":"767cb20238d6dcd87f4f7b281a07a954",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -159,7 +160,7 @@
         }
     ],
     "wof:id":1091703335,
-    "wof:lastmodified":1636500484,
+    "wof:lastmodified":1695886753,
     "wof:name":"Lae",
     "wof:parent_id":85676579,
     "wof:placetype":"county",

--- a/data/109/170/337/1/1091703371.geojson
+++ b/data/109/170/337/1/1091703371.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.396266,
-    "geom:area_square_m":4878247716.542973,
+    "geom:area_square_m":4878248081.602016,
     "geom:bbox":"142.747715,-5.787338,143.71856,-5.023332",
     "geom:latitude":-5.387005,
     "geom:longitude":143.149086,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"PG.EG.LP"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PG",
     "wof:created":1473879870,
-    "wof:geomhash":"ee8cac09d3e97d9617984cb57fdf713a",
+    "wof:geomhash":"03a226e5571cb1fc70db1d2787caa144",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091703371,
-    "wof:lastmodified":1627522501,
+    "wof:lastmodified":1695886143,
     "wof:name":"Lagaip-Porgera",
     "wof:parent_id":85676513,
     "wof:placetype":"county",

--- a/data/109/170/341/7/1091703417.geojson
+++ b/data/109/170/341/7/1091703417.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.110524,
-    "geom:area_square_m":1358023341.418659,
+    "geom:area_square_m":1358023543.272648,
     "geom:bbox":"144.989909,-6.687727,145.492537,-6.212794",
     "geom:latitude":-6.438927,
     "geom:longitude":145.256622,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"PG.EH.LF"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PG",
     "wof:created":1473879871,
-    "wof:geomhash":"277872894ddd37ebdc2f66ca2f532a6c",
+    "wof:geomhash":"70a709739b964d1390f95fd348ab9d4a",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091703417,
-    "wof:lastmodified":1627522502,
+    "wof:lastmodified":1695886143,
     "wof:name":"Lufa",
     "wof:parent_id":85676533,
     "wof:placetype":"county",

--- a/data/109/170/345/1/1091703451.geojson
+++ b/data/109/170/345/1/1091703451.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.219551,
-    "geom:area_square_m":2703835545.256962,
+    "geom:area_square_m":2703835563.316246,
     "geom:bbox":"145.19892,-5.395489,145.815414,-4.788932",
     "geom:latitude":-5.147913,
     "geom:longitude":145.520321,
@@ -138,9 +138,10 @@
     "wof:concordances":{
         "hasc:id":"PG.MD.MG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PG",
     "wof:created":1473879873,
-    "wof:geomhash":"31ea62b18f5ef023e814f33c944f4411",
+    "wof:geomhash":"79081ebe41a7d5e04593c0c7d48fc275",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -150,7 +151,7 @@
         }
     ],
     "wof:id":1091703451,
-    "wof:lastmodified":1636500485,
+    "wof:lastmodified":1695886754,
     "wof:name":"Madang",
     "wof:parent_id":85676523,
     "wof:placetype":"county",

--- a/data/109/170/347/5/1091703475.geojson
+++ b/data/109/170/347/5/1091703475.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.172701,
-    "geom:area_square_m":2134041165.102628,
+    "geom:area_square_m":2134041165.102064,
     "geom:bbox":"142.823715,-2.579611,147.880386,-1.455417",
     "geom:latitude":-2.10044,
     "geom:longitude":146.941579,
@@ -120,12 +120,13 @@
     "wof:concordances":{
         "hasc:id":"PG.MN.MN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:coterminous":[
         85676569
     ],
     "wof:country":"PG",
     "wof:created":1473879874,
-    "wof:geomhash":"01dbe2f2220280f80fe0303484b6087b",
+    "wof:geomhash":"c0e309b9bd1fd55a4b17ced7f8903d3f",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -135,7 +136,7 @@
         }
     ],
     "wof:id":1091703475,
-    "wof:lastmodified":1636500484,
+    "wof:lastmodified":1695886753,
     "wof:name":"Manus",
     "wof:parent_id":85676569,
     "wof:placetype":"county",

--- a/data/109/170/352/3/1091703523.geojson
+++ b/data/109/170/352/3/1091703523.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.069687,
-    "geom:area_square_m":859951569.951508,
+    "geom:area_square_m":859951866.309425,
     "geom:bbox":"142.826713,-3.816867,143.185812,-3.48793",
     "geom:latitude":-3.640547,
     "geom:longitude":143.025574,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"PG.ES.MP"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PG",
     "wof:created":1473879876,
-    "wof:geomhash":"907de2f4bcd07aa015a7a4d8a18339bb",
+    "wof:geomhash":"a232a80d26a6ac103fbe17bd3bf14f31",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091703523,
-    "wof:lastmodified":1627522502,
+    "wof:lastmodified":1695886143,
     "wof:name":"Maprik",
     "wof:parent_id":85676519,
     "wof:placetype":"county",

--- a/data/109/170/356/5/1091703565.geojson
+++ b/data/109/170/356/5/1091703565.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.365242,
-    "geom:area_square_m":4488477659.059343,
+    "geom:area_square_m":4488477659.05942,
     "geom:bbox":"145.864947951,-6.94695378676,146.69778813,-5.98172809203",
     "geom:latitude":-6.357436,
     "geom:longitude":146.264431,
@@ -114,9 +114,10 @@
     "wof:concordances":{
         "hasc:id":"PG.MR.KP"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PG",
     "wof:created":1473879877,
-    "wof:geomhash":"a129c27b8191526e7cb7a1a599c6064a",
+    "wof:geomhash":"b61d69804f3c8c16b2419e2a6f989e29",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -126,7 +127,7 @@
         }
     ],
     "wof:id":1091703565,
-    "wof:lastmodified":1566678541,
+    "wof:lastmodified":1695886604,
     "wof:name":"Markham",
     "wof:parent_id":85676579,
     "wof:placetype":"county",

--- a/data/109/170/358/9/1091703589.geojson
+++ b/data/109/170/358/9/1091703589.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.092009,
-    "geom:area_square_m":1131413992.99694,
+    "geom:area_square_m":1131413728.028479,
     "geom:bbox":"143.384062,-6.168667,143.889012,-5.904057",
     "geom:latitude":-6.030189,
     "geom:longitude":143.640974,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"PG.SL.MD"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PG",
     "wof:created":1473879879,
-    "wof:geomhash":"a230105175f32f83e15f57e68a871312",
+    "wof:geomhash":"ab825f95daadee407ad6b77fc341e5b4",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091703589,
-    "wof:lastmodified":1627522502,
+    "wof:lastmodified":1695886143,
     "wof:name":"Mendi-Munihu",
     "wof:parent_id":85676547,
     "wof:placetype":"county",

--- a/data/109/170/363/3/1091703633.geojson
+++ b/data/109/170/363/3/1091703633.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.300471,
-    "geom:area_square_m":3685554007.455128,
+    "geom:area_square_m":3685552828.671177,
     "geom:bbox":"145.742463,-7.65019,146.553494,-6.843614",
     "geom:latitude":-7.263094,
     "geom:longitude":146.176144,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"PG.MR.MY"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PG",
     "wof:created":1473879880,
-    "wof:geomhash":"49b28fff244b658cb73bbeabb98ab140",
+    "wof:geomhash":"7a0b0a4c6ef129a025af66c62e3fc5cc",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091703633,
-    "wof:lastmodified":1627522502,
+    "wof:lastmodified":1695886143,
     "wof:name":"Menyamya",
     "wof:parent_id":85676579,
     "wof:placetype":"county",

--- a/data/109/170/367/3/1091703673.geojson
+++ b/data/109/170/367/3/1091703673.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":4.221393,
-    "geom:area_square_m":51783404913.156815,
+    "geom:area_square_m":51783405445.679695,
     "geom:bbox":"140.841969,-8.484647,143.928757,-5.561356",
     "geom:latitude":-7.200557,
     "geom:longitude":142.273526,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"PG.WE.BM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PG",
     "wof:created":1473879882,
-    "wof:geomhash":"55e40d4aeef219168ae5a404dff3be6a",
+    "wof:geomhash":"c1e52d9c0b4bf8690f5a24a8d9e3858f",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091703673,
-    "wof:lastmodified":1627522502,
+    "wof:lastmodified":1695886143,
     "wof:name":"Middle Fly",
     "wof:parent_id":85676557,
     "wof:placetype":"county",

--- a/data/109/170/370/9/1091703709.geojson
+++ b/data/109/170/370/9/1091703709.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.637018,
-    "geom:area_square_m":7847783874.315951,
+    "geom:area_square_m":7847784160.903289,
     "geom:bbox":"143.971448,-5.368797,145.406765,-4.533944",
     "geom:latitude":-4.920397,
     "geom:longitude":144.710523,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"PG.MD.MR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PG",
     "wof:created":1473879883,
-    "wof:geomhash":"5e7f2b154367811b1eaa78b9f9fcff42",
+    "wof:geomhash":"fa0dedbbca5b8b8c8b065aa049fc0346",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091703709,
-    "wof:lastmodified":1627522502,
+    "wof:lastmodified":1695886144,
     "wof:name":"Middle Ramu",
     "wof:parent_id":85676523,
     "wof:placetype":"county",

--- a/data/109/170/373/9/1091703739.geojson
+++ b/data/109/170/373/9/1091703739.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.025885,
-    "geom:area_square_m":318418052.035553,
+    "geom:area_square_m":318418052.035538,
     "geom:bbox":"144.121403381,-5.92311250211,144.381308187,-5.75417292324",
     "geom:latitude":-5.838856,
     "geom:longitude":144.237722,
@@ -120,9 +120,10 @@
     "wof:concordances":{
         "hasc:id":"PG.WL.HC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PG",
     "wof:created":1473879885,
-    "wof:geomhash":"9a1527cc96ef9dcb921579a32046e971",
+    "wof:geomhash":"9f913fddb9535be0cba0868c75dab05b",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -132,7 +133,7 @@
         }
     ],
     "wof:id":1091703739,
-    "wof:lastmodified":1566678550,
+    "wof:lastmodified":1695886605,
     "wof:name":"Mount Hagen",
     "wof:parent_id":85676551,
     "wof:placetype":"county",

--- a/data/109/170/378/5/1091703785.geojson
+++ b/data/109/170/378/5/1091703785.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.112043,
-    "geom:area_square_m":1378994563.121002,
+    "geom:area_square_m":1378993635.345291,
     "geom:bbox":"143.988644,-5.846392,144.375147,-5.216088",
     "geom:latitude":-5.527393,
     "geom:longitude":144.164925,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"PG.WL.MB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PG",
     "wof:created":1473879886,
-    "wof:geomhash":"d1ff84deacff250073cad91dadea1b9a",
+    "wof:geomhash":"c2c894c4a5cef193da6b61dc2adf425c",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091703785,
-    "wof:lastmodified":1627522502,
+    "wof:lastmodified":1695886144,
     "wof:name":"Mul-Baiyer",
     "wof:parent_id":85676551,
     "wof:placetype":"county",

--- a/data/109/170/382/9/1091703829.geojson
+++ b/data/109/170/382/9/1091703829.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.541241,
-    "geom:area_square_m":6676746142.720158,
+    "geom:area_square_m":6676745547.26342,
     "geom:bbox":"151.429367,-4.853806,153.744583,-2.592111",
     "geom:latitude":-3.89916,
     "geom:longitude":152.550188,
@@ -78,9 +78,10 @@
     "wof:concordances":{
         "hasc:id":"PG.NI.NA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PG",
     "wof:created":1473879887,
-    "wof:geomhash":"e4f9b6673411b09145a584fa70218c01",
+    "wof:geomhash":"404c621b99720befa35f3f7b7e16d303",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -90,7 +91,7 @@
         }
     ],
     "wof:id":1091703829,
-    "wof:lastmodified":1627522502,
+    "wof:lastmodified":1695886144,
     "wof:name":"Namatanai",
     "wof:parent_id":85676587,
     "wof:placetype":"county",

--- a/data/109/170/389/9/1091703899.geojson
+++ b/data/109/170/389/9/1091703899.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.204065,
-    "geom:area_square_m":2507103830.695685,
+    "geom:area_square_m":2507102966.076519,
     "geom:bbox":"146.541247,-6.749611,147.581208,-6.25",
     "geom:latitude":-6.495812,
     "geom:longitude":146.983881,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"PG.MR.NW"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PG",
     "wof:created":1473879890,
-    "wof:geomhash":"ddded1d4bc5ca64f8e5af57d67564fd7",
+    "wof:geomhash":"1923894385eea943e30e4397fe497e5c",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091703899,
-    "wof:lastmodified":1627522502,
+    "wof:lastmodified":1695886145,
     "wof:name":"Nawae",
     "wof:parent_id":85676579,
     "wof:placetype":"county",

--- a/data/109/170/394/1/1091703941.geojson
+++ b/data/109/170/394/1/1091703941.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.63856,
-    "geom:area_square_m":7844838596.272667,
+    "geom:area_square_m":7844838499.756181,
     "geom:bbox":"142.62518,-6.83655,143.691152,-6.092714",
     "geom:latitude":-6.518363,
     "geom:longitude":143.15978,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"PG.SL.NI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PG",
     "wof:created":1473879892,
-    "wof:geomhash":"695b9f85c1884ac54246b7c1fb5a6344",
+    "wof:geomhash":"bc6ccf4240fccd958763207e4e3672ba",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091703941,
-    "wof:lastmodified":1627522502,
+    "wof:lastmodified":1695886145,
     "wof:name":"Nipa-Kutubu",
     "wof:parent_id":85676547,
     "wof:placetype":"county",

--- a/data/109/170/396/7/1091703967.geojson
+++ b/data/109/170/396/7/1091703967.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.226023,
-    "geom:area_square_m":2781341438.924572,
+    "geom:area_square_m":2781341246.42015,
     "geom:bbox":"154.106216,-6.110125,155.154864,-3.359639",
     "geom:latitude":-5.620376,
     "geom:longitude":154.82167,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"PG.NS.BK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PG",
     "wof:created":1473879893,
-    "wof:geomhash":"00a646b4ac4b6f828b3866f440320e6a",
+    "wof:geomhash":"a454def1a33c638b4b6602ea1d8aa209",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1091703967,
-    "wof:lastmodified":1627522502,
+    "wof:lastmodified":1695886145,
     "wof:name":"North Bougainville",
     "wof:parent_id":85676543,
     "wof:placetype":"county",

--- a/data/109/170/400/7/1091704007.geojson
+++ b/data/109/170/400/7/1091704007.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.232295,
-    "geom:area_square_m":15159923549.903732,
+    "geom:area_square_m":15159923296.265411,
     "geom:bbox":"140.872775,-6.652695,142.178247,-4.992097",
     "geom:latitude":-5.773712,
     "geom:longitude":141.438661,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"PG.WE.KI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PG",
     "wof:created":1473879895,
-    "wof:geomhash":"59873d608cef816ca141278f6f589366",
+    "wof:geomhash":"54f431713a5fed0d8b5bd92bc1339c71",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091704007,
-    "wof:lastmodified":1627522503,
+    "wof:lastmodified":1695886145,
     "wof:name":"North Fly",
     "wof:parent_id":85676557,
     "wof:placetype":"county",

--- a/data/109/170/404/3/1091704043.geojson
+++ b/data/109/170/404/3/1091704043.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.039315,
-    "geom:area_square_m":483659691.169256,
+    "geom:area_square_m":483659792.410842,
     "geom:bbox":"144.489639,-5.938087,144.827594,-5.68173",
     "geom:latitude":-5.792064,
     "geom:longitude":144.667571,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"PG.JI.NW"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PG",
     "wof:created":1473879897,
-    "wof:geomhash":"b182d676af824292291e86f571570c58",
+    "wof:geomhash":"0f756ebe5aeb8e96fd4f415149795768",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091704043,
-    "wof:lastmodified":1627522503,
+    "wof:lastmodified":1695886145,
     "wof:name":"North Waghi",
     "wof:parent_id":1108805613,
     "wof:placetype":"county",

--- a/data/109/170/405/7/1091704057.geojson
+++ b/data/109/170/405/7/1091704057.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.289536,
-    "geom:area_square_m":3572714265.891302,
+    "geom:area_square_m":3572714797.105875,
     "geom:bbox":"142.028897,-4.065758,142.642266,-3.370236",
     "geom:latitude":-3.692675,
     "geom:longitude":142.381219,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"PG.SA.NU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PG",
     "wof:created":1473879898,
-    "wof:geomhash":"ce6bc947806f4c38b6992bfdc854a8ea",
+    "wof:geomhash":"5902ebbd9a166593dde9891043cd70b6",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091704057,
-    "wof:lastmodified":1627522503,
+    "wof:lastmodified":1695886145,
     "wof:name":"Nuku",
     "wof:parent_id":85676525,
     "wof:placetype":"county",

--- a/data/109/170/406/1/1091704061.geojson
+++ b/data/109/170/406/1/1091704061.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.232323,
-    "geom:area_square_m":2852244027.069283,
+    "geom:area_square_m":2852244291.118488,
     "geom:bbox":"145.388004,-7.157816,146.069625,-6.514063",
     "geom:latitude":-6.842388,
     "geom:longitude":145.775155,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"PG.EH.OW"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PG",
     "wof:created":1473879900,
-    "wof:geomhash":"bdb97dd8b6c9e4421c7236ff2f426644",
+    "wof:geomhash":"f49b54075ae4ce9c71d7019019873d4b",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091704061,
-    "wof:lastmodified":1627522503,
+    "wof:lastmodified":1695886145,
     "wof:name":"Obura-Wonenara",
     "wof:parent_id":85676533,
     "wof:placetype":"county",

--- a/data/109/170/410/3/1091704103.geojson
+++ b/data/109/170/410/3/1091704103.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.1753,
-    "geom:area_square_m":2153140050.597643,
+    "geom:area_square_m":2153140148.87669,
     "geom:bbox":"145.232408,-6.932743,145.854174,-6.379629",
     "geom:latitude":-6.626002,
     "geom:longitude":145.517571,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"PG.EH.OK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PG",
     "wof:created":1473879901,
-    "wof:geomhash":"0ea87b974dbf21e8bf4483586506b166",
+    "wof:geomhash":"ba34bf7ff7d3fe51ea2f8ce5cc26f918",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1091704103,
-    "wof:lastmodified":1627522503,
+    "wof:lastmodified":1695886145,
     "wof:name":"Okapa",
     "wof:parent_id":85676533,
     "wof:placetype":"county",

--- a/data/109/170/413/9/1091704139.geojson
+++ b/data/109/170/413/9/1091704139.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.938284,
-    "geom:area_square_m":11552095875.11804,
+    "geom:area_square_m":11552096391.497181,
     "geom:bbox":"150.591938,-6.06514,152.382919,-4.444618",
     "geom:latitude":-5.304598,
     "geom:longitude":151.569924,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"PG.EN.PM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PG",
     "wof:created":1473879903,
-    "wof:geomhash":"300e113d70da133d3c95f35306da4e53",
+    "wof:geomhash":"eb1accf73ca96b071f3a053afbd8166f",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091704139,
-    "wof:lastmodified":1627522503,
+    "wof:lastmodified":1695886146,
     "wof:name":"Pomio",
     "wof:parent_id":85676565,
     "wof:placetype":"county",

--- a/data/109/170/418/1/1091704181.geojson
+++ b/data/109/170/418/1/1091704181.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.008867,
-    "geom:area_square_m":109343535.301626,
+    "geom:area_square_m":109343405.397469,
     "geom:bbox":"152.05455,-4.282917,152.23378,-4.088778",
     "geom:latitude":-4.197694,
     "geom:longitude":152.157088,
@@ -180,9 +180,10 @@
     "wof:concordances":{
         "hasc:id":"PG.EN.RL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PG",
     "wof:created":1473879905,
-    "wof:geomhash":"625c59186272747f8e82d387859a3136",
+    "wof:geomhash":"17fd3fc1890b1a1bb4a45ee2f7e96f10",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -192,7 +193,7 @@
         }
     ],
     "wof:id":1091704181,
-    "wof:lastmodified":1636500484,
+    "wof:lastmodified":1695886754,
     "wof:name":"Rabaul",
     "wof:parent_id":85676565,
     "wof:placetype":"county",

--- a/data/109/170/421/9/1091704219.geojson
+++ b/data/109/170/421/9/1091704219.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.463658,
-    "geom:area_square_m":5704826440.771218,
+    "geom:area_square_m":5704826293.231943,
     "geom:bbox":"145.543774,-6.001391,147.218781,-5.098805",
     "geom:latitude":-5.702123,
     "geom:longitude":146.179628,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"PG.MD.RC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PG",
     "wof:created":1473879907,
-    "wof:geomhash":"804dd0c78a46d48267787e4b12fe241e",
+    "wof:geomhash":"d53ccb14696aaf4904001d951e18b728",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091704219,
-    "wof:lastmodified":1627522503,
+    "wof:lastmodified":1695886146,
     "wof:name":"Rai Coast",
     "wof:parent_id":85676523,
     "wof:placetype":"county",

--- a/data/109/170/425/3/1091704253.geojson
+++ b/data/109/170/425/3/1091704253.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.413178,
-    "geom:area_square_m":5035899958.402683,
+    "geom:area_square_m":5035899958.399329,
     "geom:bbox":"147.411716887,-10.107916832,148.245270566,-9.2483642621",
     "geom:latitude":-9.703623,
     "geom:longitude":147.834924,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"PG.CE.RG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PG",
     "wof:created":1473879908,
-    "wof:geomhash":"827d546f5a06c41e4139c9f7faff7546",
+    "wof:geomhash":"c8b4d22f0017e346c3fe2008f58fd416",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1091704253,
-    "wof:lastmodified":1566678533,
+    "wof:lastmodified":1695886604,
     "wof:name":"Rigo",
     "wof:parent_id":85676561,
     "wof:placetype":"county",

--- a/data/109/170/429/9/1091704299.geojson
+++ b/data/109/170/429/9/1091704299.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.236355,
-    "geom:area_square_m":2873228764.223609,
+    "geom:area_square_m":2873229767.991991,
     "geom:bbox":"150.531636,-11.657972,154.283752,-8.902917",
     "geom:latitude":-10.494483,
     "geom:longitude":152.848646,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"PG.MB.SA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PG",
     "wof:created":1473879910,
-    "wof:geomhash":"c386d94abc0e06e9131fbb783ecaf110",
+    "wof:geomhash":"0fc42b4e8d08b1e602f50e6be14fc82a",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091704299,
-    "wof:lastmodified":1627522503,
+    "wof:lastmodified":1695886146,
     "wof:name":"Samarai-Murua",
     "wof:parent_id":85676575,
     "wof:placetype":"county",

--- a/data/109/170/434/9/1091704349.geojson
+++ b/data/109/170/434/9/1091704349.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.025433,
-    "geom:area_square_m":312713281.791541,
+    "geom:area_square_m":312712838.658901,
     "geom:bbox":"144.935391,-6.2219,145.103534,-5.966028",
     "geom:latitude":-6.088284,
     "geom:longitude":145.01985,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"PG.CH.SN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PG",
     "wof:created":1473879911,
-    "wof:geomhash":"ce5d138bb08c45fe915b134b9bd4670f",
+    "wof:geomhash":"31c7f5e92fa1f1cb4b80b3afd63ea089",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091704349,
-    "wof:lastmodified":1627522503,
+    "wof:lastmodified":1695886146,
     "wof:name":"Sina Sina-Yonggomugl",
     "wof:parent_id":85676531,
     "wof:placetype":"county",

--- a/data/109/170/439/3/1091704393.geojson
+++ b/data/109/170/439/3/1091704393.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.805067,
-    "geom:area_square_m":9844212330.487059,
+    "geom:area_square_m":9844212052.089331,
     "geom:bbox":"147.010785,-9.294536,148.254089,-7.997661",
     "geom:latitude":-8.541534,
     "geom:longitude":147.77468,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"PG.NO.KK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PG",
     "wof:created":1473879913,
-    "wof:geomhash":"83aab7d703bf5e8318260da97a8ce630",
+    "wof:geomhash":"9bfaee98af34a68306133384820cb35a",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091704393,
-    "wof:lastmodified":1627522503,
+    "wof:lastmodified":1695886146,
     "wof:name":"Sohe",
     "wof:parent_id":85676595,
     "wof:placetype":"county",

--- a/data/109/170/442/1/1091704421.geojson
+++ b/data/109/170/442/1/1091704421.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.29911,
-    "geom:area_square_m":3674418775.111747,
+    "geom:area_square_m":3674418183.200615,
     "geom:bbox":"154.952312,-6.882945,155.968781,-6.097319",
     "geom:latitude":-6.547143,
     "geom:longitude":155.486663,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"PG.NS.BN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PG",
     "wof:created":1473879914,
-    "wof:geomhash":"3dea6dd37a432d38aa363cb27d66d948",
+    "wof:geomhash":"71e8d592707620aea144862222113ab1",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091704421,
-    "wof:lastmodified":1627522504,
+    "wof:lastmodified":1695886147,
     "wof:name":"South Bougainville",
     "wof:parent_id":85676543,
     "wof:placetype":"county",

--- a/data/109/170/446/7/1091704467.geojson
+++ b/data/109/170/446/7/1091704467.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.606023,
-    "geom:area_square_m":31861087514.932419,
+    "geom:area_square_m":31861087844.002525,
     "geom:bbox":"141.018529,-9.335472,143.831284,-7.646586",
     "geom:latitude":-8.598383,
     "geom:longitude":142.036353,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"PG.WE.DA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PG",
     "wof:created":1473879916,
-    "wof:geomhash":"f107ae1d4e260436e7e093cf70e0ceea",
+    "wof:geomhash":"b46fda4fff7cb86b8f399017d0b08bdb",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091704467,
-    "wof:lastmodified":1627522504,
+    "wof:lastmodified":1695886147,
     "wof:name":"South Fly",
     "wof:parent_id":85676557,
     "wof:placetype":"county",

--- a/data/109/170/451/7/1091704517.geojson
+++ b/data/109/170/451/7/1091704517.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.158605,
-    "geom:area_square_m":1954424099.533319,
+    "geom:area_square_m":1954423770.734694,
     "geom:bbox":"145.245794,-5.043907,146.257919,-4.522083",
     "geom:latitude":-4.756168,
     "geom:longitude":145.651592,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"PG.MD.KA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PG",
     "wof:created":1473879917,
-    "wof:geomhash":"bb47cae027726ca83c2fabe80ac70c49",
+    "wof:geomhash":"a3089d5475b50c587fe396bc0795b200",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091704517,
-    "wof:lastmodified":1627522504,
+    "wof:lastmodified":1695886147,
     "wof:name":"Sumkar",
     "wof:parent_id":85676523,
     "wof:placetype":"county",

--- a/data/109/170/454/7/1091704547.geojson
+++ b/data/109/170/454/7/1091704547.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.577277,
-    "geom:area_square_m":7104704339.765695,
+    "geom:area_square_m":7104703835.206188,
     "geom:bbox":"149.74762,-6.001926,151.684771,-4.884583",
     "geom:latitude":-5.543083,
     "geom:longitude":150.49266,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"PG.WN.TL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PG",
     "wof:created":1473879919,
-    "wof:geomhash":"46cd26c2fe0cee3d40b083688a19c39f",
+    "wof:geomhash":"a782b7121059c54ee84733016118491e",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1091704547,
-    "wof:lastmodified":1627522504,
+    "wof:lastmodified":1695886148,
     "wof:name":"Talasea",
     "wof:parent_id":85676599,
     "wof:placetype":"county",

--- a/data/109/170/458/9/1091704589.geojson
+++ b/data/109/170/458/9/1091704589.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.146439,
-    "geom:area_square_m":1800866552.339863,
+    "geom:area_square_m":1800866536.18964,
     "geom:bbox":"143.772165,-6.233833,144.486155,-5.747052",
     "geom:latitude":-5.988961,
     "geom:longitude":144.148632,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"PG.WL.TR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PG",
     "wof:created":1473879920,
-    "wof:geomhash":"fdc414a2e6acc163c578a64ae6704b1f",
+    "wof:geomhash":"54ca0427ee70c79cb01706ac8f13e027",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091704589,
-    "wof:lastmodified":1627522504,
+    "wof:lastmodified":1695886148,
     "wof:name":"Tambul-Nebilyer",
     "wof:parent_id":85676551,
     "wof:placetype":"county",

--- a/data/109/170/463/7/1091704637.geojson
+++ b/data/109/170/463/7/1091704637.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.084105,
-    "geom:area_square_m":1034662025.208849,
+    "geom:area_square_m":1034662173.32349,
     "geom:bbox":"142.79215,-6.040225,143.154142,-5.610898",
     "geom:latitude":-5.795606,
     "geom:longitude":142.963374,
@@ -67,9 +67,10 @@
     "wof:concordances":{
         "hasc:id":"PG.HE.TA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PG",
     "wof:created":1473879922,
-    "wof:geomhash":"3663fd717a1755afab6aac50676279b1",
+    "wof:geomhash":"99021e4c288f6ce80e8ad6b429262322",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -85,7 +86,7 @@
         }
     ],
     "wof:id":1091704637,
-    "wof:lastmodified":1627522504,
+    "wof:lastmodified":1695886148,
     "wof:name":"Tari-Pori",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/109/170/467/9/1091704679.geojson
+++ b/data/109/170/467/9/1091704679.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.108633,
-    "geom:area_square_m":13662433792.288055,
+    "geom:area_square_m":13662433792.287813,
     "geom:bbox":"141.001091,-5.37540671912,142.325134052,-3.66124233437",
     "geom:latitude":-4.676757,
     "geom:longitude":141.697489,
@@ -78,9 +78,10 @@
     "wof:concordances":{
         "hasc:id":"PG.SA.TE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PG",
     "wof:created":1473879923,
-    "wof:geomhash":"a090c77508b468c9c9e489371da4be94",
+    "wof:geomhash":"b67abc356cd77ddefb7681636db903e1",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -90,7 +91,7 @@
         }
     ],
     "wof:id":1091704679,
-    "wof:lastmodified":1566678546,
+    "wof:lastmodified":1695886604,
     "wof:name":"Telefomin",
     "wof:parent_id":85676525,
     "wof:placetype":"county",

--- a/data/109/170/471/9/1091704719.geojson
+++ b/data/109/170/471/9/1091704719.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.215443,
-    "geom:area_square_m":2649830249.557061,
+    "geom:area_square_m":2649830875.304983,
     "geom:bbox":"146.720346,-6.377923,148.114609,-5.282917",
     "geom:latitude":-5.906371,
     "geom:longitude":147.546444,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"PG.MR.SS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PG",
     "wof:created":1473879925,
-    "wof:geomhash":"7b620692a22ef8c37a88f0be78fd24cf",
+    "wof:geomhash":"87b8b4f2c41872522a6e33c087a2bb92",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091704719,
-    "wof:lastmodified":1627522504,
+    "wof:lastmodified":1695886148,
     "wof:name":"Tewae-Siassi",
     "wof:parent_id":85676579,
     "wof:placetype":"county",

--- a/data/109/170/477/1/1091704771.geojson
+++ b/data/109/170/477/1/1091704771.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.072514,
-    "geom:area_square_m":891558481.940972,
+    "geom:area_square_m":891558775.856146,
     "geom:bbox":"145.248772,-6.28405,145.66535,-5.906131",
     "geom:latitude":-6.108286,
     "geom:longitude":145.474523,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"PG.EH.UB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PG",
     "wof:created":1473879927,
-    "wof:geomhash":"8e083c7f9e86d55ecd68af752f610c68",
+    "wof:geomhash":"4e9527712e54f245186ddf8d3690bd7c",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091704771,
-    "wof:lastmodified":1627522504,
+    "wof:lastmodified":1695886148,
     "wof:name":"Unggai-Bena",
     "wof:parent_id":85676533,
     "wof:placetype":"county",

--- a/data/109/170/481/9/1091704819.geojson
+++ b/data/109/170/481/9/1091704819.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.577781,
-    "geom:area_square_m":7111269555.20142,
+    "geom:area_square_m":7111269709.503863,
     "geom:bbox":"144.584468,-5.998373,146.019837,-4.948968",
     "geom:latitude":-5.512558,
     "geom:longitude":145.207139,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"PG.MD.UB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PG",
     "wof:created":1473879929,
-    "wof:geomhash":"52db1235fdaf2c3daa2be2a0266668b6",
+    "wof:geomhash":"3a2dacf35db6553f0d9bad440fb252e7",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091704819,
-    "wof:lastmodified":1627522504,
+    "wof:lastmodified":1695886148,
     "wof:name":"Usino-Bundi",
     "wof:parent_id":85676523,
     "wof:placetype":"county",

--- a/data/109/170/490/1/1091704901.geojson
+++ b/data/109/170/490/1/1091704901.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.031791,
-    "geom:area_square_m":12735067627.093021,
+    "geom:area_square_m":12735067707.005732,
     "geom:bbox":"141.00109,-4.272126,141.861476,-2.604591",
     "geom:latitude":-3.432263,
     "geom:longitude":141.347313,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"PG.SA.VA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PG",
     "wof:created":1473879932,
-    "wof:geomhash":"9cdd46697be65323eeed39cb06a97c8e",
+    "wof:geomhash":"0d6516efead31543ecf30a49412894e4",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091704901,
-    "wof:lastmodified":1627522504,
+    "wof:lastmodified":1695886148,
     "wof:name":"Vanimo-Green River",
     "wof:parent_id":85676525,
     "wof:placetype":"county",

--- a/data/109/170/498/3/1091704983.geojson
+++ b/data/109/170/498/3/1091704983.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.076733,
-    "geom:area_square_m":944724894.817408,
+    "geom:area_square_m":944725262.589097,
     "geom:bbox":"143.319032,-5.613999,143.852188,-5.065814",
     "geom:latitude":-5.323933,
     "geom:longitude":143.575491,
@@ -135,9 +135,10 @@
     "wof:concordances":{
         "hasc:id":"PG.EG.WB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PG",
     "wof:created":1473879935,
-    "wof:geomhash":"fd0e1e400fd1647b602b871962501cfa",
+    "wof:geomhash":"54e752c10efb7717a262e192848bd40d",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -147,7 +148,7 @@
         }
     ],
     "wof:id":1091704983,
-    "wof:lastmodified":1636500483,
+    "wof:lastmodified":1695886753,
     "wof:name":"Wabag",
     "wof:parent_id":85676513,
     "wof:placetype":"county",

--- a/data/109/170/505/5/1091705055.geojson
+++ b/data/109/170/505/5/1091705055.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.082984,
-    "geom:area_square_m":1021095107.317118,
+    "geom:area_square_m":1021094689.354483,
     "geom:bbox":"143.708484,-5.837936,144.054371,-5.481602",
     "geom:latitude":-5.668987,
     "geom:longitude":143.873925,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"PG.EG.WP"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PG",
     "wof:created":1473879938,
-    "wof:geomhash":"003a5c4d3a409fae9ae20f0f716790dd",
+    "wof:geomhash":"d693673d79fadedfadb1d39859d9ccfd",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091705055,
-    "wof:lastmodified":1627522505,
+    "wof:lastmodified":1695886148,
     "wof:name":"Wapenamanda",
     "wof:parent_id":85676513,
     "wof:placetype":"county",

--- a/data/109/170/508/9/1091705089.geojson
+++ b/data/109/170/508/9/1091705089.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.182994,
-    "geom:area_square_m":2258268641.163729,
+    "geom:area_square_m":2258269106.511914,
     "geom:bbox":"143.084615,-3.989258,144.834549,-3.20625",
     "geom:latitude":-3.607172,
     "geom:longitude":143.57091,
@@ -147,9 +147,10 @@
     "wof:concordances":{
         "hasc:id":"PG.ES.WE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PG",
     "wof:created":1473879939,
-    "wof:geomhash":"ae8b4ec4f15beabc812ce46ed6755e80",
+    "wof:geomhash":"2c3ee88f0f4a6d80514002f3f4dd9d64",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -159,7 +160,7 @@
         }
     ],
     "wof:id":1091705089,
-    "wof:lastmodified":1636500484,
+    "wof:lastmodified":1695886754,
     "wof:name":"Wewak",
     "wof:parent_id":85676519,
     "wof:placetype":"county",

--- a/data/109/170/513/1/1091705131.geojson
+++ b/data/109/170/513/1/1091705131.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.257492,
-    "geom:area_square_m":3175942751.778398,
+    "geom:area_square_m":3175942598.578247,
     "geom:bbox":"142.627971,-4.491641,143.352002,-3.690486",
     "geom:latitude":-4.056001,
     "geom:longitude":143.063109,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"PG.ES.WG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PG",
     "wof:created":1473879941,
-    "wof:geomhash":"09118e328ba6f0fc53197e1fd7adc002",
+    "wof:geomhash":"9bc63bf40ccc8a76794b198030499276",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091705131,
-    "wof:lastmodified":1627522505,
+    "wof:lastmodified":1695886149,
     "wof:name":"Wosera-Gawi",
     "wof:parent_id":85676519,
     "wof:placetype":"county",

--- a/data/109/170/517/9/1091705179.geojson
+++ b/data/109/170/517/9/1091705179.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.212238,
-    "geom:area_square_m":2618552736.190017,
+    "geom:area_square_m":2618552779.229401,
     "geom:bbox":"143.165568,-4.002551,143.84419,-3.532134",
     "geom:latitude":-3.81173,
     "geom:longitude":143.460997,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"PG.ES.YS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PG",
     "wof:created":1473879942,
-    "wof:geomhash":"c5c7fd3942cc55715e010fe8a9380bd8",
+    "wof:geomhash":"80bfc6a7db45b60d6be1bc0f6abf93fa",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091705179,
-    "wof:lastmodified":1627522505,
+    "wof:lastmodified":1695886149,
     "wof:name":"Yangoro-Saussia",
     "wof:parent_id":85676519,
     "wof:placetype":"county",

--- a/data/110/880/561/3/1108805613.geojson
+++ b/data/110/880/561/3/1108805613.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.397024,
-    "geom:area_square_m":4884126130.785919,
+    "geom:area_square_m":4884127057.460464,
     "geom:bbox":"144.273802,-6.389439,145.023082,-5.216829",
     "geom:latitude":-5.795443,
     "geom:longitude":144.593497,
@@ -128,12 +128,14 @@
     "wof:concordances":{
         "fips:code":"PP22",
         "hasc:id":"PG.JI",
+        "iso:code":"PG-JWK",
         "iso:id":"PG-JWK",
         "wd:id":"Q1400625"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"PG",
     "wof:created":1485542317,
-    "wof:geomhash":"39e13af8c04f8430d87c8d1235ec26ab",
+    "wof:geomhash":"adc1928bc50123a059e3f2d9f0815e25",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -152,7 +154,7 @@
         "eng",
         "hmo"
     ],
-    "wof:lastmodified":1690850838,
+    "wof:lastmodified":1695884329,
     "wof:name":"Jiwaka",
     "wof:parent_id":85632347,
     "wof:placetype":"region",

--- a/data/110/880/561/5/1108805615.geojson
+++ b/data/110/880/561/5/1108805615.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.799144,
-    "geom:area_square_m":9832905652.037819,
+    "geom:area_square_m":9832905356.275738,
     "geom:bbox":"142.06756,-6.358051,143.413512,-4.945202",
     "geom:latitude":-5.678305,
     "geom:longitude":142.734364,
@@ -131,12 +131,14 @@
     "wof:concordances":{
         "fips:code":"PP21",
         "hasc:id":"PG.HE",
+        "iso:code":"PG-HLA",
         "iso:id":"PG-HLA",
         "wd:id":"Q1382499"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"PG",
     "wof:created":1485542319,
-    "wof:geomhash":"1a67a19d66b5c650dc742f136218b5dc",
+    "wof:geomhash":"eaf59b73a5f4ae9e72856b8ae91ada1b",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -155,7 +157,7 @@
         "eng",
         "hmo"
     ],
-    "wof:lastmodified":1690850839,
+    "wof:lastmodified":1695884329,
     "wof:name":"Hela",
     "wof:parent_id":85632347,
     "wof:placetype":"region",

--- a/data/856/323/47/85632347.geojson
+++ b/data/856/323/47/85632347.geojson
@@ -1245,6 +1245,7 @@
         "hasc:id":"PG",
         "icao:code":"P2",
         "ioc:id":"PNG",
+        "iso:code":"PG",
         "itu:id":"PNG",
         "loc:id":"n81034915",
         "m49:code":"598",
@@ -1259,6 +1260,7 @@
         "wk:page":"Papua New Guinea",
         "wmo:id":"NG"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"PG",
     "wof:country_alpha3":"PNG",
     "wof:geom_alt":[
@@ -1284,7 +1286,7 @@
         "eng",
         "hmo"
     ],
-    "wof:lastmodified":1694639526,
+    "wof:lastmodified":1695881181,
     "wof:name":"Papua New Guinea",
     "wof:parent_id":102191583,
     "wof:placetype":"country",

--- a/data/856/765/13/85676513.geojson
+++ b/data/856/765/13/85676513.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.960343,
-    "geom:area_square_m":11821338935.608175,
+    "geom:area_square_m":11821339193.537123,
     "geom:bbox":"142.747715,-5.978645,144.248473,-5.008059",
     "geom:latitude":-5.435936,
     "geom:longitude":143.472421,
@@ -295,17 +295,19 @@
         "gn:id":2097655,
         "gp:id":2346599,
         "hasc:id":"PG.EG",
+        "iso:code":"PG-EPW",
         "iso:id":"PG-EPW",
         "qs_pg:id":219599,
         "unlc:id":"PG-EPW",
         "wd:id":"Q862584",
         "wk:page":"Enga Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"PG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"7422eef8cc448a018e50a05682e87e2b",
+    "wof:geomhash":"045e25a3537a8c8635016536fd4242a7",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -324,7 +326,7 @@
         "eng",
         "hmo"
     ],
-    "wof:lastmodified":1690850833,
+    "wof:lastmodified":1695884869,
     "wof:name":"Enga",
     "wof:parent_id":85632347,
     "wof:placetype":"region",

--- a/data/856/765/19/85676519.geojson
+++ b/data/856/765/19/85676519.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.548087,
-    "geom:area_square_m":43747534548.017792,
+    "geom:area_square_m":43747534679.241226,
     "geom:bbox":"141.335071,-5.158184,144.834549,-3.20625",
     "geom:latitude":-4.312176,
     "geom:longitude":143.171442,
@@ -302,17 +302,19 @@
         "gn:id":2097846,
         "gp:id":2346591,
         "hasc:id":"PG.ES",
+        "iso:code":"PG-ESW",
         "iso:id":"PG-ESW",
         "qs_pg:id":235626,
         "unlc:id":"PG-ESW",
         "wd:id":"Q690880",
         "wk:page":"East Sepik Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"PG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ac6595c0ec7a041de16d07038fc522b3",
+    "wof:geomhash":"1591201c01273b6f20416032f9230f93",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -331,7 +333,7 @@
         "eng",
         "hmo"
     ],
-    "wof:lastmodified":1690850829,
+    "wof:lastmodified":1695884867,
     "wof:name":"East Sepik",
     "wof:parent_id":85632347,
     "wof:placetype":"region",

--- a/data/856/765/23/85676523.geojson
+++ b/data/856/765/23/85676523.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.359246,
-    "geom:area_square_m":29053295510.339405,
+    "geom:area_square_m":29053294829.986454,
     "geom:bbox":"143.971448,-6.001391,147.218781,-4.000548",
     "geom:latitude":-5.16029,
     "geom:longitude":145.286534,
@@ -295,17 +295,19 @@
         "gn:id":2091993,
         "gp:id":2346592,
         "hasc:id":"PG.MD",
+        "iso:code":"PG-MPM",
         "iso:id":"PG-MPM",
         "qs_pg:id":423913,
         "unlc:id":"PG-MPM",
         "wd:id":"Q326254",
         "wk:page":"Madang Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"PG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"3aa9c42140c354564d96ad1ccb28b101",
+    "wof:geomhash":"20ae7e5e90976f95382501c9911fdf2a",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -324,7 +326,7 @@
         "eng",
         "hmo"
     ],
-    "wof:lastmodified":1690850833,
+    "wof:lastmodified":1695884868,
     "wof:name":"Madang",
     "wof:parent_id":85632347,
     "wof:placetype":"region",

--- a/data/856/765/25/85676525.geojson
+++ b/data/856/765/25/85676525.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.901286,
-    "geom:area_square_m":35788431132.43988,
+    "geom:area_square_m":35788432616.089165,
     "geom:bbox":"141.00109,-5.375407,143.09055,-2.604591",
     "geom:latitude":-3.916276,
     "geom:longitude":141.716504,
@@ -303,16 +303,18 @@
         "gn:id":2087246,
         "gp:id":2346598,
         "hasc:id":"PG.SA",
+        "iso:code":"PG-SAN",
         "iso:id":"PG-SAN",
         "qs_pg:id":219598,
         "wd:id":"Q753689",
         "wk:page":"Sandaun Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"PG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"423e5b545e6d97f0fe588d08e207fcb0",
+    "wof:geomhash":"82fae07029fd53067623b92546fddd04",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -331,7 +333,7 @@
         "eng",
         "hmo"
     ],
-    "wof:lastmodified":1690850834,
+    "wof:lastmodified":1695884869,
     "wof:name":"Sandaun",
     "wof:parent_id":85632347,
     "wof:placetype":"region",

--- a/data/856/765/31/85676531.geojson
+++ b/data/856/765/31/85676531.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.503281,
-    "geom:area_square_m":6184976116.083162,
+    "geom:area_square_m":6184975556.510695,
     "geom:bbox":"144.423151,-6.871516,145.348156,-5.775556",
     "geom:latitude":-6.344523,
     "geom:longitude":144.921421,
@@ -295,17 +295,19 @@
         "gn:id":2098593,
         "gp:id":2346588,
         "hasc:id":"PG.CH",
+        "iso:code":"PG-CPK",
         "iso:id":"PG-CPK",
         "qs_pg:id":222829,
         "unlc:id":"PG-CPK",
         "wd:id":"Q599448",
         "wk:page":"Chimbu Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"PG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"93840a7dc9360eef30ea755e4894a97d",
+    "wof:geomhash":"7a52daae3047a87c62d7f455ba3ce3a5",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -324,7 +326,7 @@
         "eng",
         "hmo"
     ],
-    "wof:lastmodified":1690850831,
+    "wof:lastmodified":1695884868,
     "wof:name":"Chimbu",
     "wof:parent_id":85632347,
     "wof:placetype":"region",

--- a/data/856/765/33/85676533.geojson
+++ b/data/856/765/33/85676533.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.911359,
-    "geom:area_square_m":11197227461.527702,
+    "geom:area_square_m":11197227480.926723,
     "geom:bbox":"144.989909,-7.157816,146.134208,-5.852974",
     "geom:latitude":-6.468417,
     "geom:longitude":145.608841,
@@ -299,17 +299,19 @@
         "gn:id":2097855,
         "gp:id":2346589,
         "hasc:id":"PG.EH",
+        "iso:code":"PG-EHG",
         "iso:id":"PG-EHG",
         "qs_pg:id":219597,
         "unlc:id":"PG-EHG",
         "wd:id":"Q849812",
         "wk:page":"Eastern Highlands Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"PG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"12d5774d28b53f1328c27c605bcf1409",
+    "wof:geomhash":"807f22d9bcac17f5bbeb65efbc1d10bd",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -328,7 +330,7 @@
         "eng",
         "hmo"
     ],
-    "wof:lastmodified":1690850828,
+    "wof:lastmodified":1695884866,
     "wof:name":"Eastern Highlands",
     "wof:parent_id":85632347,
     "wof:placetype":"region",

--- a/data/856/765/39/85676539.geojson
+++ b/data/856/765/39/85676539.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.858697,
-    "geom:area_square_m":35054981260.470215,
+    "geom:area_square_m":35054982736.699242,
     "geom:bbox":"142.990373,-8.58276,146.652965,-6.699639",
     "geom:latitude":-7.378577,
     "geom:longitude":144.800735,
@@ -283,17 +283,19 @@
         "gn:id":2096633,
         "gp:id":2346582,
         "hasc:id":"PG.GU",
+        "iso:code":"PG-GPK",
         "iso:id":"PG-GPK",
         "qs_pg:id":1004450,
         "unlc:id":"PG-GPK",
         "wd:id":"Q874980",
         "wk:page":"Gulf Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"PG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"83848f5f418211d80c7393ef25fccc05",
+    "wof:geomhash":"a6f7eecdaf2f80f3b072a575beeb39f8",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -312,7 +314,7 @@
         "eng",
         "hmo"
     ],
-    "wof:lastmodified":1690850831,
+    "wof:lastmodified":1695884868,
     "wof:name":"Gulf",
     "wof:parent_id":85632347,
     "wof:placetype":"region",

--- a/data/856/765/43/85676543.geojson
+++ b/data/856/765/43/85676543.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.769021,
-    "geom:area_square_m":9454050508.07671,
+    "geom:area_square_m":9454049812.599941,
     "geom:bbox":"154.106216,-6.882945,155.968781,-3.359639",
     "geom:latitude":-6.151657,
     "geom:longitude":155.258217,
@@ -332,16 +332,18 @@
         "gn:id":2089470,
         "gp:id":2346587,
         "hasc:id":"PG.NS",
+        "iso:code":"PG-NSB",
         "iso:id":"PG-NSB",
         "qs_pg:id":222828,
         "wd:id":"Q18826",
         "wk:page":"Autonomous Region of Bougainville"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"PG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"2a532fb835bd38eaa70da91b85d91fbe",
+    "wof:geomhash":"97790da30e3d7eb576dd00bae93882bc",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -360,7 +362,7 @@
         "eng",
         "hmo"
     ],
-    "wof:lastmodified":1690850830,
+    "wof:lastmodified":1695884868,
     "wof:name":"North Solomons",
     "wof:parent_id":85632347,
     "wof:placetype":"region",

--- a/data/856/765/47/85676547.geojson
+++ b/data/856/765/47/85676547.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.304648,
-    "geom:area_square_m":16029808354.536652,
+    "geom:area_square_m":16029808054.103899,
     "geom:bbox":"142.62518,-6.83655,144.687738,-5.904057",
     "geom:latitude":-6.455866,
     "geom:longitude":143.587709,
@@ -298,17 +298,19 @@
         "gn:id":2086331,
         "gp:id":2346585,
         "hasc:id":"PG.SL",
+        "iso:code":"PG-SHM",
         "iso:id":"PG-SHM",
         "qs_pg:id":423902,
         "unlc:id":"PG-SHM",
         "wd:id":"Q849801",
         "wk:page":"Southern Highlands Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"PG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"9b839d5fd6e43e25d4449d65ac7175a2",
+    "wof:geomhash":"40d3978920862ce78c8f4e1a81039a6e",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -327,7 +329,7 @@
         "eng",
         "hmo"
     ],
-    "wof:lastmodified":1690850833,
+    "wof:lastmodified":1695884869,
     "wof:name":"Southern Highlands",
     "wof:parent_id":85632347,
     "wof:placetype":"region",

--- a/data/856/765/51/85676551.geojson
+++ b/data/856/765/51/85676551.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.348459,
-    "geom:area_square_m":4286926456.889098,
+    "geom:area_square_m":4286925796.226811,
     "geom:bbox":"143.772165,-6.233833,144.514772,-5.216088",
     "geom:latitude":-5.766182,
     "geom:longitude":144.197846,
@@ -296,17 +296,19 @@
         "gn:id":2083551,
         "gp:id":2346596,
         "hasc:id":"PG.WL",
+        "iso:code":"PG-WHM",
         "iso:id":"PG-WHM",
         "qs_pg:id":894968,
         "unlc:id":"PG-WHM",
         "wd:id":"Q849807",
         "wk:page":"Western Highlands Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"PG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"96a6c9af0737b915810198b7cf730eab",
+    "wof:geomhash":"1f42e12aa85eb5f191eabb1d06fc894a",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -325,7 +327,7 @@
         "eng",
         "hmo"
     ],
-    "wof:lastmodified":1690850828,
+    "wof:lastmodified":1695884866,
     "wof:name":"Western Highlands",
     "wof:parent_id":85632347,
     "wof:placetype":"region",

--- a/data/856/765/57/85676557.geojson
+++ b/data/856/765/57/85676557.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":8.059711,
-    "geom:area_square_m":98804415978.001221,
+    "geom:area_square_m":98804416585.938568,
     "geom:bbox":"140.841969,-9.335472,143.928757,-4.992097",
     "geom:latitude":-7.434371,
     "geom:longitude":142.069191,
@@ -243,16 +243,18 @@
         "gn:id":2083549,
         "gp:id":2346586,
         "hasc:id":"PG.WE",
+        "iso:code":"PG-WPD",
         "iso:id":"PG-WPD",
         "qs_pg:id":318591,
         "wd:id":"Q849790",
         "wk:page":"Western Province (Papua New Guinea)"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"PG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"9811730fbc6a58adcaaa066290d67df7",
+    "wof:geomhash":"f1111866b30c0ce3f5bfb7630ffbf6b2",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -271,7 +273,7 @@
         "eng",
         "hmo"
     ],
-    "wof:lastmodified":1690850827,
+    "wof:lastmodified":1695884867,
     "wof:name":"Western",
     "wof:parent_id":85632347,
     "wof:placetype":"region",

--- a/data/856/765/61/85676561.geojson
+++ b/data/856/765/61/85676561.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.430917,
-    "geom:area_square_m":29670535841.457455,
+    "geom:area_square_m":29670535611.688072,
     "geom:bbox":"146.374442,-10.37125,149.66684,-7.768499",
     "geom:latitude":-9.192515,
     "geom:longitude":147.615524,
@@ -298,17 +298,19 @@
         "gn:id":2133763,
         "gp:id":2346581,
         "hasc:id":"PG.CE",
+        "iso:code":"PG-CPM",
         "iso:id":"PG-CPM",
         "qs_pg:id":894962,
         "unlc:id":"PG-CPM",
         "wd:id":"Q874942",
         "wk:page":"Central Province (Papua New Guinea)"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"PG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"7d8fc2c8849fa32515ca5e0493ce1b52",
+    "wof:geomhash":"c45868145222c134e352b83ada4687c5",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -327,7 +329,7 @@
         "eng",
         "hmo"
     ],
-    "wof:lastmodified":1690850827,
+    "wof:lastmodified":1695884866,
     "wof:name":"Central",
     "wof:parent_id":85632347,
     "wof:placetype":"region",

--- a/data/856/765/65/85676565.geojson
+++ b/data/856/765/65/85676565.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.25208,
-    "geom:area_square_m":15420483744.876474,
+    "geom:area_square_m":15420484961.705143,
     "geom:bbox":"150.591938,-6.06514,152.49791,-4.088778",
     "geom:latitude":-5.092507,
     "geom:longitude":151.648386,
@@ -319,17 +319,19 @@
         "gn:id":2097853,
         "gp:id":2346590,
         "hasc:id":"PG.EN",
+        "iso:code":"PG-EBR",
         "iso:id":"PG-EBR",
         "qs_pg:id":235625,
         "unlc:id":"PG-EBR",
         "wd:id":"Q753702",
         "wk:page":"East New Britain Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"PG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f87dc99f8061b511e43f6861c13c71cc",
+    "wof:geomhash":"f6ae68aca3585e5e86718ca1c95adaa9",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -348,7 +350,7 @@
         "eng",
         "hmo"
     ],
-    "wof:lastmodified":1690850831,
+    "wof:lastmodified":1695884868,
     "wof:name":"East New Britain",
     "wof:parent_id":85632347,
     "wof:placetype":"region",

--- a/data/856/765/69/85676569.geojson
+++ b/data/856/765/69/85676569.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.172701,
-    "geom:area_square_m":2134041165.102628,
+    "geom:area_square_m":2134041165.102064,
     "geom:bbox":"142.823715,-2.579611,147.880386,-1.455417",
     "geom:latitude":-2.10044,
     "geom:longitude":146.941579,
@@ -292,12 +292,14 @@
         "gn:id":2091495,
         "gp:id":2346593,
         "hasc:id":"PG.MN",
+        "iso:code":"PG-MRL",
         "iso:id":"PG-MRL",
         "qs_pg:id":1047219,
         "unlc:id":"PG-MRL",
         "wd:id":"Q874935",
         "wk:page":"Manus Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:coterminous":[
         1091703475
     ],
@@ -305,7 +307,7 @@
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"01dbe2f2220280f80fe0303484b6087b",
+    "wof:geomhash":"c0e309b9bd1fd55a4b17ced7f8903d3f",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -324,7 +326,7 @@
         "eng",
         "hmo"
     ],
-    "wof:lastmodified":1690850828,
+    "wof:lastmodified":1695884867,
     "wof:name":"Manus",
     "wof:parent_id":85632347,
     "wof:placetype":"region",

--- a/data/856/765/75/85676575.geojson
+++ b/data/856/765/75/85676575.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.178216,
-    "geom:area_square_m":14344170663.896088,
+    "geom:area_square_m":14344172563.910572,
     "geom:bbox":"148.965223,-11.657972,154.283752,-8.327056",
     "geom:latitude":-10.055587,
     "geom:longitude":150.695555,
@@ -286,17 +286,19 @@
         "gn:id":2132895,
         "gp:id":2346583,
         "hasc:id":"PG.MB",
+        "iso:code":"PG-MBA",
         "iso:id":"PG-MBA",
         "qs_pg:id":1083860,
         "unlc:id":"PG-MBA",
         "wd:id":"Q874962",
         "wk:page":"Milne Bay Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"PG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f8dec04a3ac5116f8b747439be8f362d",
+    "wof:geomhash":"87a57f774ed5788905da273b2b217ca8",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -315,7 +317,7 @@
         "eng",
         "hmo"
     ],
-    "wof:lastmodified":1690850830,
+    "wof:lastmodified":1695884867,
     "wof:name":"Milne Bay",
     "wof:parent_id":85632347,
     "wof:placetype":"region",

--- a/data/856/765/79/85676579.geojson
+++ b/data/856/765/79/85676579.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.776599,
-    "geom:area_square_m":34087428021.234001,
+    "geom:area_square_m":34087427530.514645,
     "geom:bbox":"145.742463,-8.032415,148.114609,-5.282917",
     "geom:latitude":-6.831884,
     "geom:longitude":146.838535,
@@ -298,17 +298,19 @@
         "gn:id":2090468,
         "gp:id":2346594,
         "hasc:id":"PG.MR",
+        "iso:code":"PG-MPL",
         "iso:id":"PG-MPL",
         "qs_pg:id":894967,
         "unlc:id":"PG-MPL",
         "wd:id":"Q853664",
         "wk:page":"Morobe Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"PG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"aa647f3b2eff3edabfd6f4673029cab6",
+    "wof:geomhash":"b7179171ee6ce8a43e30990065441b86",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -327,7 +329,7 @@
         "eng",
         "hmo"
     ],
-    "wof:lastmodified":1690850832,
+    "wof:lastmodified":1695884868,
     "wof:name":"Morobe",
     "wof:parent_id":85632347,
     "wof:placetype":"region",

--- a/data/856/765/81/85676581.geojson
+++ b/data/856/765/81/85676581.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.022017,
-    "geom:area_square_m":268557992.586174,
+    "geom:area_square_m":268557406.532567,
     "geom:bbox":"147.066254,-9.542111,147.290375,-9.356406",
     "geom:latitude":-9.43676,
     "geom:longitude":147.196089,
@@ -235,10 +235,12 @@
         "gn:id":2089856,
         "gp:id":2346600,
         "hasc:id":"PG.NC",
+        "iso:code":"PG-NCD",
         "iso:id":"PG-NCD",
         "qs_pg:id":1047220,
         "wd:id":"Q1378310"
     },
+    "wof:concordances_official":"iso:code",
     "wof:coterminous":[
         890444183
     ],
@@ -246,7 +248,7 @@
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"01dcdf56eb2dfca7913c860c7863fb59",
+    "wof:geomhash":"ff92dce6d9c2622f9ec47d0440caa521",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -265,7 +267,7 @@
         "eng",
         "hmo"
     ],
-    "wof:lastmodified":1690850830,
+    "wof:lastmodified":1695884360,
     "wof:name":"National Capital District",
     "wof:parent_id":85632347,
     "wof:placetype":"region",

--- a/data/856/765/87/85676587.geojson
+++ b/data/856/765/87/85676587.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.783081,
-    "geom:area_square_m":9664150791.178001,
+    "geom:area_square_m":9664149859.537411,
     "geom:bbox":"149.505386,-4.853806,153.744583,-1.315444",
     "geom:latitude":-3.475702,
     "geom:longitude":151.928057,
@@ -304,17 +304,19 @@
         "gn:id":2089693,
         "gp:id":2346595,
         "hasc:id":"PG.NI",
+        "iso:code":"PG-NIK",
         "iso:id":"PG-NIK",
         "qs_pg:id":423914,
         "unlc:id":"PG-NIK",
         "wd:id":"Q838690",
         "wk:page":"New Ireland Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"PG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"40b5fdd4489f7dd76609237bb98e3de6",
+    "wof:geomhash":"b2e32fb18d6ba429fa7630b36fe75dca",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -333,7 +335,7 @@
         "eng",
         "hmo"
     ],
-    "wof:lastmodified":1690850829,
+    "wof:lastmodified":1695884867,
     "wof:name":"New Ireland",
     "wof:parent_id":85632347,
     "wof:placetype":"region",

--- a/data/856/765/95/85676595.geojson
+++ b/data/856/765/95/85676595.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.862544,
-    "geom:area_square_m":22747513439.745102,
+    "geom:area_square_m":22747513485.80619,
     "geom:bbox":"147.010785,-9.975395,149.439021,-7.997661",
     "geom:latitude":-8.979895,
     "geom:longitude":148.250476,
@@ -310,17 +310,19 @@
         "gn:id":2089478,
         "gp:id":2346584,
         "hasc:id":"PG.NO",
+        "iso:code":"PG-NPP",
         "iso:id":"PG-NPP",
         "qs_pg:id":1083861,
         "unlc:id":"PG-NPP",
         "wd:id":"Q753686",
         "wk:page":"Oro Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"PG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"32fbdc77170b7ab6f4598480e377b15f",
+    "wof:geomhash":"3c0e67ecce77bbea2250afff573a4456",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -339,7 +341,7 @@
         "eng",
         "hmo"
     ],
-    "wof:lastmodified":1690850827,
+    "wof:lastmodified":1695884866,
     "wof:name":"Northern",
     "wof:parent_id":85632347,
     "wof:placetype":"region",

--- a/data/856/765/99/85676599.geojson
+++ b/data/856/765/99/85676599.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.661584,
-    "geom:area_square_m":20442007883.627045,
+    "geom:area_square_m":20442008051.476093,
     "geom:bbox":"148.306229,-6.317945,151.684771,-4.617084",
     "geom:latitude":-5.75502,
     "geom:longitude":149.837258,
@@ -319,17 +319,19 @@
         "gn:id":2083546,
         "gp:id":2346597,
         "hasc:id":"PG.WN",
+        "iso:code":"PG-WBK",
         "iso:id":"PG-WBK",
         "qs_pg:id":894969,
         "unlc:id":"PG-WBK",
         "wd:id":"Q667468",
         "wk:page":"West New Britain Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"PG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"aae8e5d243423791a3494e2289516b59",
+    "wof:geomhash":"0c52910df734bb4365512a47bc9589e2",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -348,7 +350,7 @@
         "eng",
         "hmo"
     ],
-    "wof:lastmodified":1690850832,
+    "wof:lastmodified":1695884869,
     "wof:name":"West New Britain",
     "wof:parent_id":85632347,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.